### PR TITLE
PANDO-32: Add `IPrimitiveSerializer`

### DIFF
--- a/docs/GuidelinesExamples/ArrayExample.md
+++ b/docs/GuidelinesExamples/ArrayExample.md
@@ -22,7 +22,7 @@ public record Company(      // Company is a branch
 
 ### `CompanyName` and `EmployeeNames[i]`
 
-Strings can be complicated since in a UTF8 string a character can be 2-4 bytes. For this memory layout example we'll
+Strings can be complicated since in a UTF8 string a character can be 1-4 bytes. For this memory layout example we'll
 assume all of the characters are 2 bytes, however in a real-world scenario any UTF8 string should work.
 
 You could also write a custom serializer for a ASCII only string, etc.

--- a/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
@@ -7,6 +7,17 @@ public class BooleanSerializer : IPrimitiveSerializer<bool>
 {
 	public static BooleanSerializer Default { get; } = new();
 
+	private const int SIZE = 1;
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(bool value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(bool value, ref Span<byte> buffer)
 	{

--- a/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class BooleanSerializer : IPrimitiveSerializer<bool>
+{
+	public static BooleanSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(bool value, ref Span<byte> buffer)
+	{
+		buffer[0] = (byte)(value ? 1 : 0);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public bool Deserialize(ReadOnlySpan<byte> buffer) => buffer[0] != 0;
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -19,11 +20,16 @@ public class BooleanSerializer : IPrimitiveSerializer<bool>
 	public int ByteCountForValue(bool value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(bool value, Span<byte> buffer)
+	public void Serialize(bool value, ref Span<byte> buffer)
 	{
-		buffer[0] = (byte)(value ? 1 : 0);
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		slice[0] = (byte)(value ? 1 : 0);
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool Deserialize(ReadOnlySpan<byte> buffer) => buffer[0] != 0;
+	public bool Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return slice[0] != 0;
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
@@ -19,7 +19,7 @@ public class BooleanSerializer : IPrimitiveSerializer<bool>
 	public int ByteCountForValue(bool value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(bool value, ref Span<byte> buffer)
+	public void Serialize(bool value, Span<byte> buffer)
 	{
 		buffer[0] = (byte)(value ? 1 : 0);
 	}

--- a/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class ByteSerializer : IPrimitiveSerializer<byte>
+{
+	public static ByteSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(byte value, ref Span<byte> buffer) { buffer[0] = value; }
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public byte Deserialize(ReadOnlySpan<byte> buffer) => buffer[0];
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
@@ -19,7 +19,7 @@ public class ByteSerializer : IPrimitiveSerializer<byte>
 	public int ByteCountForValue(byte value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(byte value, ref Span<byte> buffer) { buffer[0] = value; }
+	public void Serialize(byte value, Span<byte> buffer) { buffer[0] = value; }
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public byte Deserialize(ReadOnlySpan<byte> buffer) => buffer[0];

--- a/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -19,8 +20,16 @@ public class ByteSerializer : IPrimitiveSerializer<byte>
 	public int ByteCountForValue(byte value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(byte value, Span<byte> buffer) { buffer[0] = value; }
+	public void Serialize(byte value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		slice[0] = value;
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public byte Deserialize(ReadOnlySpan<byte> buffer) => buffer[0];
+	public byte Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return slice[0];
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
@@ -7,6 +7,17 @@ public class ByteSerializer : IPrimitiveSerializer<byte>
 {
 	public static ByteSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(byte);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(byte value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(byte value, ref Span<byte> buffer) { buffer[0] = value; }
 

--- a/src/Pando/Serialization/PrimitiveSerializers/DateOnlyDayNumberSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/DateOnlyDayNumberSerializer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class DateOnlyDayNumberSerializer : IPrimitiveSerializer<DateOnly>
+{
+	public static DateOnlyDayNumberSerializer Default { get; } = new();
+
+	private readonly IPrimitiveSerializer<int> _innerSerializer;
+
+	public DateOnlyDayNumberSerializer() : this(Int32LittleEndianSerializer.Default) { }
+
+	public DateOnlyDayNumberSerializer(IPrimitiveSerializer<int> intSerializer)
+	{
+		_innerSerializer = intSerializer;
+		ByteCount = _innerSerializer.ByteCount;
+	}
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(DateOnly value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.DayNumber);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(DateOnly value, Span<byte> buffer) => _innerSerializer.Serialize(value.DayNumber, buffer);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public DateOnly Deserialize(ReadOnlySpan<byte> buffer) => DateOnly.FromDayNumber(_innerSerializer.Deserialize(buffer));
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/DateOnlyDayNumberSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/DateOnlyDayNumberSerializer.cs
@@ -27,8 +27,8 @@ public class DateOnlyDayNumberSerializer : IPrimitiveSerializer<DateOnly>
 	public int ByteCountForValue(DateOnly value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.DayNumber);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(DateOnly value, Span<byte> buffer) => _innerSerializer.Serialize(value.DayNumber, buffer);
+	public void Serialize(DateOnly value, ref Span<byte> buffer) => _innerSerializer.Serialize(value.DayNumber, ref buffer);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public DateOnly Deserialize(ReadOnlySpan<byte> buffer) => DateOnly.FromDayNumber(_innerSerializer.Deserialize(buffer));
+	public DateOnly Deserialize(ref ReadOnlySpan<byte> buffer) => DateOnly.FromDayNumber(_innerSerializer.Deserialize(ref buffer));
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/DateTimeUnixSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/DateTimeUnixSerializer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class DateTimeUnixSerializer : IPrimitiveSerializer<DateTime>
+{
+	public static DateTimeUnixSerializer Default { get; } = new();
+
+	private readonly IPrimitiveSerializer<long> _innerSerializer;
+
+	public DateTimeUnixSerializer() : this(Int64LittleEndianSerializer.Default) { }
+
+	public DateTimeUnixSerializer(IPrimitiveSerializer<long> longSerializer)
+	{
+		_innerSerializer = longSerializer;
+		ByteCount = _innerSerializer.ByteCount;
+	}
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(DateTime value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.ToBinary());
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(DateTime value, Span<byte> buffer) => _innerSerializer.Serialize(value.ToBinary(), buffer);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public DateTime Deserialize(ReadOnlySpan<byte> buffer) => DateTime.FromBinary(_innerSerializer.Deserialize(buffer));
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/DateTimeUnixSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/DateTimeUnixSerializer.cs
@@ -27,8 +27,8 @@ public class DateTimeUnixSerializer : IPrimitiveSerializer<DateTime>
 	public int ByteCountForValue(DateTime value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.ToBinary());
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(DateTime value, Span<byte> buffer) => _innerSerializer.Serialize(value.ToBinary(), buffer);
+	public void Serialize(DateTime value, ref Span<byte> buffer) => _innerSerializer.Serialize(value.ToBinary(), ref buffer);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public DateTime Deserialize(ReadOnlySpan<byte> buffer) => DateTime.FromBinary(_innerSerializer.Deserialize(buffer));
+	public DateTime Deserialize(ref ReadOnlySpan<byte> buffer) => DateTime.FromBinary(_innerSerializer.Deserialize(ref buffer));
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
@@ -25,34 +25,49 @@ public class EnumSerializer<TEnum> : IPrimitiveSerializer<TEnum>
 			if (_underlyingType == typeof(sbyte))
 			{
 				SByteSerializer.Default.Serialize(*(sbyte*)(&value), ref buffer);
+				return;
 			}
-			else if (_underlyingType == typeof(byte))
+
+			if (_underlyingType == typeof(byte))
 			{
 				ByteSerializer.Default.Serialize(*(byte*)(&value), ref buffer);
+				return;
 			}
-			else if (_underlyingType == typeof(short))
+
+			if (_underlyingType == typeof(short))
 			{
 				Int16LittleEndianSerializer.Default.Serialize(*(short*)(&value), ref buffer);
+				return;
 			}
-			else if (_underlyingType == typeof(ushort))
+
+			if (_underlyingType == typeof(ushort))
 			{
 				UInt16LittleEndianSerializer.Default.Serialize(*(ushort*)(&value), ref buffer);
+				return;
 			}
-			else if (_underlyingType == typeof(int))
+
+			if (_underlyingType == typeof(int))
 			{
 				Int32LittleEndianSerializer.Default.Serialize(*(int*)(&value), ref buffer);
+				return;
 			}
-			else if (_underlyingType == typeof(uint))
+
+			if (_underlyingType == typeof(uint))
 			{
 				UInt32LittleEndianSerializer.Default.Serialize(*(uint*)(&value), ref buffer);
+				return;
 			}
-			else if (_underlyingType == typeof(long))
+
+			if (_underlyingType == typeof(long))
 			{
 				Int64LittleEndianSerializer.Default.Serialize(*(long*)(&value), ref buffer);
+				return;
 			}
-			else if (_underlyingType == typeof(ulong))
+
+			if (_underlyingType == typeof(ulong))
 			{
 				UInt64LittleEndianSerializer.Default.Serialize(*(ulong*)(&value), ref buffer);
+				return;
 			}
 		}
 

--- a/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
@@ -20,16 +20,16 @@ public sealed class EnumSerializer<TEnum, TUnderlying> : IPrimitiveSerializer<TE
 	public int? ByteCount { get; }
 	public unsafe int ByteCountForValue(TEnum value) => ByteCount ?? _underlyingSerializer.ByteCountForValue(*(TUnderlying*)(&value));
 
-	public unsafe void Serialize(TEnum value, Span<byte> buffer)
+	public unsafe void Serialize(TEnum value, ref Span<byte> buffer)
 	{
 		var underlying = *(TUnderlying*)(&value);
-		_underlyingSerializer.Serialize(underlying, buffer);
+		_underlyingSerializer.Serialize(underlying, ref buffer);
 	}
 
-	public unsafe TEnum Deserialize(ReadOnlySpan<byte> buffer)
+	public unsafe TEnum Deserialize(ref ReadOnlySpan<byte> buffer)
 	{
-		var underlyingValue = _underlyingSerializer.Deserialize(buffer);
-		return *(TEnum*)(&underlyingValue);
+		var underlying = _underlyingSerializer.Deserialize(ref buffer);
+		return *(TEnum*)(&underlying);
 	}
 }
 
@@ -65,10 +65,11 @@ public static class EnumSerializer
 
 		if (actualUnderlyingType != givenUnderlyingType)
 		{
-			throw new NotSupportedException(
+			throw new ArgumentException(
 				"The given underlying serializer does not match the underlying type of the given enum type." +
 				$" Given enum has underlying type {actualUnderlyingType.FullName}" +
-				$" while the given serializer serializes type {givenUnderlyingType.FullName}."
+				$" while the given serializer serializes type {givenUnderlyingType.FullName}.",
+				nameof(underlyingSerializer)
 			);
 		}
 

--- a/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
@@ -20,10 +20,10 @@ public sealed class EnumSerializer<TEnum, TUnderlying> : IPrimitiveSerializer<TE
 	public int? ByteCount { get; }
 	public unsafe int ByteCountForValue(TEnum value) => ByteCount ?? _underlyingSerializer.ByteCountForValue(*(TUnderlying*)(&value));
 
-	public unsafe void Serialize(TEnum value, ref Span<byte> buffer)
+	public unsafe void Serialize(TEnum value, Span<byte> buffer)
 	{
 		var underlying = *(TUnderlying*)(&value);
-		_underlyingSerializer.Serialize(underlying, ref buffer);
+		_underlyingSerializer.Serialize(underlying, buffer);
 	}
 
 	public unsafe TEnum Deserialize(ReadOnlySpan<byte> buffer)

--- a/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
@@ -1,0 +1,119 @@
+using System;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class EnumSerializer<TEnum> : IPrimitiveSerializer<TEnum>
+	where TEnum : unmanaged, Enum
+{
+	private readonly Type _underlyingType;
+
+	public EnumSerializer()
+	{
+		var enumType = typeof(TEnum);
+		_underlyingType = enumType.GetEnumUnderlyingType();
+
+		if (_underlyingType == typeof(nint) || _underlyingType == typeof(nuint))
+		{
+			throw new ArgumentException($"{_underlyingType.FullName} is not a valid underlying type for EnumSerializer");
+		}
+	}
+
+	public void Serialize(TEnum value, ref Span<byte> buffer)
+	{
+		unsafe
+		{
+			if (_underlyingType == typeof(sbyte))
+			{
+				SByteSerializer.Default.Serialize(*(sbyte*)(&value), ref buffer);
+			}
+			else if (_underlyingType == typeof(byte))
+			{
+				ByteSerializer.Default.Serialize(*(byte*)(&value), ref buffer);
+			}
+			else if (_underlyingType == typeof(short))
+			{
+				Int16LittleEndianSerializer.Default.Serialize(*(short*)(&value), ref buffer);
+			}
+			else if (_underlyingType == typeof(ushort))
+			{
+				UInt16LittleEndianSerializer.Default.Serialize(*(ushort*)(&value), ref buffer);
+			}
+			else if (_underlyingType == typeof(int))
+			{
+				Int32LittleEndianSerializer.Default.Serialize(*(int*)(&value), ref buffer);
+			}
+			else if (_underlyingType == typeof(uint))
+			{
+				UInt32LittleEndianSerializer.Default.Serialize(*(uint*)(&value), ref buffer);
+			}
+			else if (_underlyingType == typeof(long))
+			{
+				Int64LittleEndianSerializer.Default.Serialize(*(long*)(&value), ref buffer);
+			}
+			else if (_underlyingType == typeof(ulong))
+			{
+				UInt64LittleEndianSerializer.Default.Serialize(*(ulong*)(&value), ref buffer);
+			}
+		}
+
+		// This shouldn't happen because we account for all possible underlying types (except nint and nuint, which are caught in the constructor)
+		throw new Exception($"Can't serialize enum with underlying type {_underlyingType.FullName}");
+	}
+
+	public TEnum Deserialize(ReadOnlySpan<byte> buffer)
+	{
+		unsafe
+		{
+			if (_underlyingType == typeof(sbyte))
+			{
+				var underlyingValue = SByteSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+
+			if (_underlyingType == typeof(byte))
+			{
+				var underlyingValue = ByteSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+
+			if (_underlyingType == typeof(short))
+			{
+				var underlyingValue = Int16LittleEndianSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+
+			if (_underlyingType == typeof(ushort))
+			{
+				var underlyingValue = UInt16LittleEndianSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+
+			if (_underlyingType == typeof(int))
+			{
+				var underlyingValue = Int32LittleEndianSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+
+			if (_underlyingType == typeof(uint))
+			{
+				var underlyingValue = UInt32LittleEndianSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+
+			if (_underlyingType == typeof(long))
+			{
+				var underlyingValue = Int64LittleEndianSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+
+			if (_underlyingType == typeof(ulong))
+			{
+				var underlyingValue = UInt64LittleEndianSerializer.Default.Deserialize(buffer);
+				return *(TEnum*)(&underlyingValue);
+			}
+		}
+
+		// This shouldn't happen because we account for all possible underlying types (except nint and nuint, which are caught in the constructor)
+		throw new Exception($"Can't deserialize enum with underlying type {_underlyingType.FullName}");
+	}
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
@@ -14,7 +14,11 @@ public sealed class EnumSerializer<TEnum, TUnderlying> : IPrimitiveSerializer<TE
 		// This is relatively safe because the only way to construct an EnumSerializer is via the provided factory methods,
 		// which create serializers based on the underlying type of the given enum.
 		_underlyingSerializer = underlyingSerializer;
+		ByteCount = _underlyingSerializer.ByteCount;
 	}
+
+	public int? ByteCount { get; }
+	public unsafe int ByteCountForValue(TEnum value) => ByteCount ?? _underlyingSerializer.ByteCountForValue(*(TUnderlying*)(&value));
 
 	public unsafe void Serialize(TEnum value, ref Span<byte> buffer)
 	{

--- a/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
@@ -14,7 +14,7 @@ public interface IPrimitiveSerializer<T>
 	public int ByteCountForValue(T value);
 
 	/// Serializes the given value into the given byte buffer
-	public void Serialize(T value, ref Span<byte> buffer);
+	public void Serialize(T value, Span<byte> buffer);
 
 	/// Deserializes a value from the given byte buffer
 	public T Deserialize(ReadOnlySpan<byte> buffer);

--- a/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
@@ -13,9 +13,9 @@ public interface IPrimitiveSerializer<T>
 	/// This should always be possible to calculate for a given input, so it is not nullable like <see cref="ByteCount"/>.
 	public int ByteCountForValue(T value);
 
-	/// Serializes the given value into the given byte buffer
-	public void Serialize(T value, Span<byte> buffer);
+	/// Serializes the given value into the start of the given buffer, then slices the buffer to the remaining space after the write
+	public void Serialize(T value, ref Span<byte> buffer);
 
-	/// Deserializes a value from the given byte buffer
-	public T Deserialize(ReadOnlySpan<byte> buffer);
+	/// Deserializes a value from the given byte buffer, then slices the buffer to the remaining unread space
+	public T Deserialize(ref ReadOnlySpan<byte> buffer);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
@@ -4,6 +4,15 @@ namespace Pando.Serialization.PrimitiveSerializers;
 
 public interface IPrimitiveSerializer<T>
 {
+	/// The size in bytes of the data produced by this serializer, if known.
+	/// If the size can be dynamic, should return null.
+	/// <remarks>This should be constant after initialization. If the size of the data can vary, return null</remarks>
+	public int? ByteCount { get; }
+
+	/// The size in bytes of the data that would be produced by this serializer based on the given concrete value.
+	/// This should always be possible to calculate for a given input, so it is not nullable like <see cref="ByteCount"/>.
+	public int ByteCountForValue(T value);
+
 	/// Serializes the given value into the given byte buffer
 	public void Serialize(T value, ref Span<byte> buffer);
 

--- a/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public interface IPrimitiveSerializer<T>
+{
+	/// Serializes the given value into the given byte buffer
+	public void Serialize(T value, ref Span<byte> buffer);
+
+	/// Deserializes a value from the given byte buffer
+	public T Deserialize(ReadOnlySpan<byte> buffer);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -20,8 +21,16 @@ public class Int16LittleEndianSerializer : IPrimitiveSerializer<short>
 	public int ByteCountForValue(short value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(short value, Span<byte> buffer) => BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
+	public void Serialize(short value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		BinaryPrimitives.WriteInt16LittleEndian(slice, value);
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public short Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt16LittleEndian(buffer);
+	public short Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return BinaryPrimitives.ReadInt16LittleEndian(slice);
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class Int16LittleEndianSerializer : IPrimitiveSerializer<short>
+{
+	public static Int16LittleEndianSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(short value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public short Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt16LittleEndian(buffer);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
@@ -20,7 +20,7 @@ public class Int16LittleEndianSerializer : IPrimitiveSerializer<short>
 	public int ByteCountForValue(short value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(short value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
+	public void Serialize(short value, Span<byte> buffer) => BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public short Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt16LittleEndian(buffer);

--- a/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
@@ -8,6 +8,17 @@ public class Int16LittleEndianSerializer : IPrimitiveSerializer<short>
 {
 	public static Int16LittleEndianSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(short);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(short value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(short value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
 

--- a/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
@@ -20,7 +20,7 @@ public class Int32LittleEndianSerializer : IPrimitiveSerializer<int>
 	public int ByteCountForValue(int value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(int value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+	public void Serialize(int value, Span<byte> buffer) => BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public int Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt32LittleEndian(buffer);

--- a/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -20,8 +21,16 @@ public class Int32LittleEndianSerializer : IPrimitiveSerializer<int>
 	public int ByteCountForValue(int value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(int value, Span<byte> buffer) => BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+	public void Serialize(int value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		BinaryPrimitives.WriteInt32LittleEndian(slice, value);
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt32LittleEndian(buffer);
+	public int Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return BinaryPrimitives.ReadInt32LittleEndian(slice);
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
@@ -8,6 +8,17 @@ public class Int32LittleEndianSerializer : IPrimitiveSerializer<int>
 {
 	public static Int32LittleEndianSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(int);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(int value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(int value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
 

--- a/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class Int32LittleEndianSerializer : IPrimitiveSerializer<int>
+{
+	public static Int32LittleEndianSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(int value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt32LittleEndian(buffer);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class Int64LittleEndianSerializer : IPrimitiveSerializer<long>
+{
+	public static Int64LittleEndianSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(long value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public long Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt64LittleEndian(buffer);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
@@ -8,6 +8,17 @@ public class Int64LittleEndianSerializer : IPrimitiveSerializer<long>
 {
 	public static Int64LittleEndianSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(long);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(long value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(long value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
 

--- a/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -20,8 +21,16 @@ public class Int64LittleEndianSerializer : IPrimitiveSerializer<long>
 	public int ByteCountForValue(long value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(long value, Span<byte> buffer) => BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
+	public void Serialize(long value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		BinaryPrimitives.WriteInt64LittleEndian(slice, value);
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public long Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt64LittleEndian(buffer);
+	public long Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return BinaryPrimitives.ReadInt64LittleEndian(slice);
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
@@ -20,7 +20,7 @@ public class Int64LittleEndianSerializer : IPrimitiveSerializer<long>
 	public int ByteCountForValue(long value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(long value, ref Span<byte> buffer) => BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
+	public void Serialize(long value, Span<byte> buffer) => BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public long Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadInt64LittleEndian(buffer);

--- a/src/Pando/Serialization/PrimitiveSerializers/NullableSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/NullableSerializer.cs
@@ -1,0 +1,50 @@
+using System;
+using Pando.Serialization.Utils;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class NullableSerializer<T> : IPrimitiveSerializer<T?>
+	where T : struct
+{
+	private readonly IPrimitiveSerializer<T> _innerSerializer;
+
+	/// The number of bytes used to store the null state of the value
+	private const int NULL_FLAG_SIZE = 1;
+
+	public NullableSerializer(IPrimitiveSerializer<T> innerSerializer)
+	{
+		_innerSerializer = innerSerializer;
+	}
+
+	// Size is variable because if the value is null then we just store an empty byte.
+	public int? ByteCount => null;
+
+	public int ByteCountForValue(T? value) =>
+		value is not null
+			? NULL_FLAG_SIZE + (_innerSerializer.ByteCount ?? _innerSerializer.ByteCountForValue(value.Value))
+			: NULL_FLAG_SIZE; // just a single empty byte in the null case
+
+	public void Serialize(T? value, ref Span<byte> buffer)
+	{
+		var nullFlag = SpanHelpers.PopStart(ref buffer, NULL_FLAG_SIZE);
+		if (value is not null)
+		{
+			nullFlag[0] = 1;
+			_innerSerializer.Serialize(value.Value, ref buffer);
+		}
+		else
+		{
+			nullFlag[0] = 0;
+		}
+	}
+
+	public T? Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var nullFlag = SpanHelpers.PopStart(ref buffer, NULL_FLAG_SIZE);
+
+		if (nullFlag[0] == 0) return null;
+
+		var value = _innerSerializer.Deserialize(ref buffer);
+		return value;
+	}
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class SByteSerializer : IPrimitiveSerializer<sbyte>
+{
+	public static SByteSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(sbyte value, ref Span<byte> buffer) { buffer[0] = (byte)value; }
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public sbyte Deserialize(ReadOnlySpan<byte> buffer) => (sbyte)buffer[0];
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -19,8 +20,16 @@ public class SByteSerializer : IPrimitiveSerializer<sbyte>
 	public int ByteCountForValue(sbyte value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(sbyte value, Span<byte> buffer) { buffer[0] = (byte)value; }
+	public void Serialize(sbyte value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		slice[0] = (byte)value;
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public sbyte Deserialize(ReadOnlySpan<byte> buffer) => (sbyte)buffer[0];
+	public sbyte Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return (sbyte)slice[0];
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
@@ -19,7 +19,7 @@ public class SByteSerializer : IPrimitiveSerializer<sbyte>
 	public int ByteCountForValue(sbyte value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(sbyte value, ref Span<byte> buffer) { buffer[0] = (byte)value; }
+	public void Serialize(sbyte value, Span<byte> buffer) { buffer[0] = (byte)value; }
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public sbyte Deserialize(ReadOnlySpan<byte> buffer) => (sbyte)buffer[0];

--- a/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
@@ -7,6 +7,17 @@ public class SByteSerializer : IPrimitiveSerializer<sbyte>
 {
 	public static SByteSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(sbyte);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(sbyte value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(sbyte value, ref Span<byte> buffer) { buffer[0] = (byte)value; }
 

--- a/src/Pando/Serialization/PrimitiveSerializers/TimeOnlyTicksSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/TimeOnlyTicksSerializer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class TimeOnlyTicksSerializer : IPrimitiveSerializer<TimeOnly>
+{
+	public static TimeOnlyTicksSerializer Default { get; } = new();
+
+	private readonly IPrimitiveSerializer<long> _innerSerializer;
+
+	public TimeOnlyTicksSerializer() : this(Int64LittleEndianSerializer.Default) { }
+
+	public TimeOnlyTicksSerializer(IPrimitiveSerializer<long> longSerializer)
+	{
+		_innerSerializer = longSerializer;
+		ByteCount = _innerSerializer.ByteCount;
+	}
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(TimeOnly value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.Ticks);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(TimeOnly value, Span<byte> buffer) => _innerSerializer.Serialize(value.Ticks, buffer);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public TimeOnly Deserialize(ReadOnlySpan<byte> buffer) => new(_innerSerializer.Deserialize(buffer));
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/TimeOnlyTicksSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/TimeOnlyTicksSerializer.cs
@@ -27,8 +27,8 @@ public class TimeOnlyTicksSerializer : IPrimitiveSerializer<TimeOnly>
 	public int ByteCountForValue(TimeOnly value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.Ticks);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(TimeOnly value, Span<byte> buffer) => _innerSerializer.Serialize(value.Ticks, buffer);
+	public void Serialize(TimeOnly value, ref Span<byte> buffer) => _innerSerializer.Serialize(value.Ticks, ref buffer);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public TimeOnly Deserialize(ReadOnlySpan<byte> buffer) => new(_innerSerializer.Deserialize(buffer));
+	public TimeOnly Deserialize(ref ReadOnlySpan<byte> buffer) => new(_innerSerializer.Deserialize(ref buffer));
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/TimeSpanTicksSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/TimeSpanTicksSerializer.cs
@@ -27,8 +27,8 @@ public class TimeSpanTicksSerializer : IPrimitiveSerializer<TimeSpan>
 	public int ByteCountForValue(TimeSpan value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.Ticks);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(TimeSpan value, Span<byte> buffer) => _innerSerializer.Serialize(value.Ticks, buffer);
+	public void Serialize(TimeSpan value, ref Span<byte> buffer) => _innerSerializer.Serialize(value.Ticks, ref buffer);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public TimeSpan Deserialize(ReadOnlySpan<byte> buffer) => TimeSpan.FromTicks(_innerSerializer.Deserialize(buffer));
+	public TimeSpan Deserialize(ref ReadOnlySpan<byte> buffer) => TimeSpan.FromTicks(_innerSerializer.Deserialize(ref buffer));
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/TimeSpanTicksSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/TimeSpanTicksSerializer.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class TimeSpanTicksSerializer : IPrimitiveSerializer<TimeSpan>
+{
+	public static TimeSpanTicksSerializer Default { get; } = new();
+
+	private readonly IPrimitiveSerializer<long> _innerSerializer;
+
+	public TimeSpanTicksSerializer() : this(Int64LittleEndianSerializer.Default) { }
+
+	public TimeSpanTicksSerializer(IPrimitiveSerializer<long> longSerializer)
+	{
+		_innerSerializer = longSerializer;
+		ByteCount = _innerSerializer.ByteCount;
+	}
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(TimeSpan value) => ByteCount ?? _innerSerializer.ByteCountForValue(value.Ticks);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(TimeSpan value, Span<byte> buffer) => _innerSerializer.Serialize(value.Ticks, buffer);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public TimeSpan Deserialize(ReadOnlySpan<byte> buffer) => TimeSpan.FromTicks(_innerSerializer.Deserialize(buffer));
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -20,8 +21,16 @@ public class UInt16LittleEndianSerializer : IPrimitiveSerializer<ushort>
 	public int ByteCountForValue(ushort value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(ushort value, Span<byte> buffer) => BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
+	public void Serialize(ushort value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		BinaryPrimitives.WriteUInt16LittleEndian(slice, value);
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public ushort Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+	public ushort Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return BinaryPrimitives.ReadUInt16LittleEndian(slice);
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class UInt16LittleEndianSerializer : IPrimitiveSerializer<ushort>
+{
+	public static UInt16LittleEndianSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(ushort value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public ushort Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
@@ -20,7 +20,7 @@ public class UInt16LittleEndianSerializer : IPrimitiveSerializer<ushort>
 	public int ByteCountForValue(ushort value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(ushort value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
+	public void Serialize(ushort value, Span<byte> buffer) => BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ushort Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt16LittleEndian(buffer);

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
@@ -8,6 +8,17 @@ public class UInt16LittleEndianSerializer : IPrimitiveSerializer<ushort>
 {
 	public static UInt16LittleEndianSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(ushort);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(ushort value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(ushort value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
 

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
@@ -20,7 +20,7 @@ public class UInt32LittleEndianSerializer : IPrimitiveSerializer<uint>
 	public int ByteCountForValue(uint value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(uint value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+	public void Serialize(uint value, Span<byte> buffer) => BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public uint Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt32LittleEndian(buffer);

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
@@ -8,6 +8,17 @@ public class UInt32LittleEndianSerializer : IPrimitiveSerializer<uint>
 {
 	public static UInt32LittleEndianSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(uint);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(uint value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(uint value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
 

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -20,8 +21,16 @@ public class UInt32LittleEndianSerializer : IPrimitiveSerializer<uint>
 	public int ByteCountForValue(uint value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(uint value, Span<byte> buffer) => BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+	public void Serialize(uint value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		BinaryPrimitives.WriteUInt32LittleEndian(slice, value);
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public uint Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+	public uint Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return BinaryPrimitives.ReadUInt32LittleEndian(slice);
+	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class UInt32LittleEndianSerializer : IPrimitiveSerializer<uint>
+{
+	public static UInt32LittleEndianSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(uint value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public uint Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
@@ -20,7 +20,7 @@ public class UInt64LittleEndianSerializer : IPrimitiveSerializer<ulong>
 	public int ByteCountForValue(ulong value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(ulong value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+	public void Serialize(ulong value, Span<byte> buffer) => BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ulong Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt64LittleEndian(buffer);

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public class UInt64LittleEndianSerializer : IPrimitiveSerializer<ulong>
+{
+	public static UInt64LittleEndianSerializer Default { get; } = new();
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(ulong value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public ulong Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
@@ -8,6 +8,17 @@ public class UInt64LittleEndianSerializer : IPrimitiveSerializer<ulong>
 {
 	public static UInt64LittleEndianSerializer Default { get; } = new();
 
+	private const int SIZE = sizeof(ulong);
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => SIZE;
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int ByteCountForValue(ulong value) => SIZE;
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Serialize(ulong value, ref Span<byte> buffer) => BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
 

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
@@ -20,8 +21,16 @@ public class UInt64LittleEndianSerializer : IPrimitiveSerializer<ulong>
 	public int ByteCountForValue(ulong value) => SIZE;
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(ulong value, Span<byte> buffer) => BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+	public void Serialize(ulong value, ref Span<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		BinaryPrimitives.WriteUInt64LittleEndian(slice, value);
+	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public ulong Deserialize(ReadOnlySpan<byte> buffer) => BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+	public ulong Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
+		return BinaryPrimitives.ReadUInt64LittleEndian(slice);
+	}
 }

--- a/src/Pando/Serialization/Utils/SpanHelpers.cs
+++ b/src/Pando/Serialization/Utils/SpanHelpers.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.Utils;
+
+public static class SpanHelpers
+{
+	/// Removes the given number of elements from the start of the span and returns them
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static Span<T> PopStart<T>(ref Span<T> input, int length)
+	{
+		var start = input[..length];
+		input = input[length..];
+		return start;
+	}
+
+	/// Removes the given number of elements from the start of the span and returns them
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static ReadOnlySpan<T> PopStart<T>(ref ReadOnlySpan<T> input, int length)
+	{
+		var start = input[..length];
+		input = input[length..];
+		return start;
+	}
+}

--- a/tests/PandoTests/Tests/Repositories/PandoRepositoryTests.cs
+++ b/tests/PandoTests/Tests/Repositories/PandoRepositoryTests.cs
@@ -85,7 +85,7 @@ public class PandoRepositoryTests
 			// Assert
 			actual.Should()
 				.NotBeSameAs(tree)
-				.And.BeEquivalentTo(tree);
+				.And.BeEquivalentTo(tree, options => options.ComparingByMembers<TestTree>());
 		}
 
 		[Fact]

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -27,7 +27,7 @@ public class EnumSerializerTest
 
 		// Serialize
 		Span<byte> buffer = stackalloc byte[bytes.Length];
-		serializer.Serialize(value, ref buffer);
+		serializer.Serialize(value, buffer);
 		var serializationResult = buffer.ToArray();
 
 		serializationResult.Should().BeEquivalentTo(bytes);

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Pando.Serialization.PrimitiveSerializers;
+using Xunit;
+
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+public record struct TestData<T>(T Value, byte[] Bytes);
+
+public class EnumSerializerTest
+{
+	[Theory]
+	[ClassData(typeof(SByteEnumSerializerTestData))]
+	[ClassData(typeof(ByteEnumSerializerTestData))]
+	[ClassData(typeof(Int16EnumSerializerTestData))]
+	[ClassData(typeof(UInt16EnumSerializerTestData))]
+	[ClassData(typeof(Int32EnumSerializerTestData))]
+	[ClassData(typeof(UInt32EnumSerializerTestData))]
+	[ClassData(typeof(Int64EnumSerializerTestData))]
+	[ClassData(typeof(UInt64EnumSerializerTestData))]
+	public void Serialize_Deserialize<T>(TestData<T> testData, IPrimitiveSerializer<T> serializer)
+	{
+		var (value, bytes) = testData;
+
+		// Serialize
+		Span<byte> buffer = stackalloc byte[bytes.Length];
+		serializer.Serialize(value, ref buffer);
+		var serializationResult = buffer.ToArray();
+
+		serializationResult.Should().BeEquivalentTo(bytes);
+
+		// Deserialize
+		var deserializationResult = serializer.Deserialize(bytes);
+
+		deserializationResult.Should().BeEquivalentTo(value);
+	}
+}
+
+public abstract class BaseTestData<T> : IEnumerable<object[]>
+{
+	protected abstract IPrimitiveSerializer<T> ProduceSerializer();
+	protected abstract IEnumerable<TestData<T>> ProduceTestData();
+
+	public IEnumerator<object[]> GetEnumerator() => ProduceTestData().Select(td => new object[] { td, ProduceSerializer() }).GetEnumerator();
+	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+public abstract class BaseEnumTestData<T> : BaseTestData<T>
+	where T : unmanaged, Enum
+{
+	protected override IPrimitiveSerializer<T> ProduceSerializer() => new EnumSerializer<T>();
+}
+
+public class SByteEnumSerializerTestData : BaseEnumTestData<SByteEnum>
+{
+	protected override IEnumerable<TestData<SByteEnum>> ProduceTestData() => new List<TestData<SByteEnum>>
+	{
+		new(SByteEnum.Min, new byte[] { 0x80 }),
+		new(SByteEnum.Mid1, new byte[] { 0xC8 }),
+		new(SByteEnum.Mid2, new byte[] { 0x5B }),
+		new(SByteEnum.Max, new byte[] { 0x7F }),
+	};
+}
+
+public class ByteEnumSerializerTestData : BaseEnumTestData<ByteEnum>
+{
+	protected override IEnumerable<TestData<ByteEnum>> ProduceTestData() => new List<TestData<ByteEnum>>
+	{
+		new(ByteEnum.Min, new byte[] { 0x00 }),
+		new(ByteEnum.Mid1, new byte[] { 0x25 }),
+		new(ByteEnum.Mid2, new byte[] { 0xB8 }),
+		new(ByteEnum.Max, new byte[] { 0xFF }),
+	};
+}
+
+public class Int16EnumSerializerTestData : BaseEnumTestData<Int16Enum>
+{
+	protected override IEnumerable<TestData<Int16Enum>> ProduceTestData() => new List<TestData<Int16Enum>>
+	{
+		new(Int16Enum.Min, new byte[] { 0x00, 0x80 }),
+		new(Int16Enum.Mid1, new byte[] { 0x1F, 0xC8 }),
+		new(Int16Enum.Mid2, new byte[] { 0xC0, 0x5B }),
+		new(Int16Enum.Max, new byte[] { 0xFF, 0x7F }),
+	};
+}
+
+public class UInt16EnumSerializerTestData : BaseEnumTestData<UInt16Enum>
+{
+	protected override IEnumerable<TestData<UInt16Enum>> ProduceTestData() => new List<TestData<UInt16Enum>>
+	{
+		new(UInt16Enum.Min, new byte[] { 0x00, 0x00 }),
+		new(UInt16Enum.Mid1, new byte[] { 0x40, 0x24 }),
+		new(UInt16Enum.Mid2, new byte[] { 0xE1, 0xB7 }),
+		new(UInt16Enum.Max, new byte[] { 0xFF, 0xFF }),
+	};
+}
+
+public class Int32EnumSerializerTestData : BaseEnumTestData<Int32Enum>
+{
+	protected override IEnumerable<TestData<Int32Enum>> ProduceTestData() => new List<TestData<Int32Enum>>
+	{
+		new(Int32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x80 }),
+		new(Int32Enum.Mid1, new byte[] { 0x9E, 0xAE, 0x1E, 0xC8 }),
+		new(Int32Enum.Mid2, new byte[] { 0x77, 0x95, 0xC0, 0x5B }),
+		new(Int32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }),
+	};
+}
+
+public class UInt32EnumSerializerTestData : BaseEnumTestData<UInt32Enum>
+{
+	protected override IEnumerable<TestData<UInt32Enum>> ProduceTestData() => new List<TestData<UInt32Enum>>
+	{
+		new(UInt32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00 }),
+		new(UInt32Enum.Mid1, new byte[] { 0x89, 0x6A, 0x3F, 0x24 }),
+		new(UInt32Enum.Mid2, new byte[] { 0x62, 0x51, 0xE1, 0xB7 }),
+		new(UInt32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }),
+	};
+}
+
+public class Int64EnumSerializerTestData : BaseEnumTestData<Int64Enum>
+{
+	protected override IEnumerable<TestData<Int64Enum>> ProduceTestData() => new List<TestData<Int64Enum>>
+	{
+		new(Int64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }),
+		new(Int64Enum.Mid1, new byte[] { 0x00, 0xDC, 0x12, 0x75, 0x9D, 0xAE, 0x1E, 0xC8 }),
+		new(Int64Enum.Mid2, new byte[] { 0x00, 0xF8, 0x5C, 0x7A, 0x77, 0x95, 0xC0, 0x5B }),
+		new(Int64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }),
+	};
+}
+
+public class UInt64EnumSerializerTestData : BaseEnumTestData<UInt64Enum>
+{
+	protected override IEnumerable<TestData<UInt64Enum>> ProduceTestData() => new List<TestData<UInt64Enum>>
+	{
+		new(UInt64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }),
+		new(UInt64Enum.Mid1, new byte[] { 0x00, 0xFE, 0xA2, 0x85, 0x88, 0x6A, 0x3F, 0x24 }),
+		new(UInt64Enum.Mid2, new byte[] { 0x00, 0x18, 0xED, 0x8A, 0x62, 0x51, 0xE1, 0xB7 }),
+		new(UInt64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }),
+	};
+}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -51,7 +51,7 @@ public abstract class BaseTestData<T> : IEnumerable<object[]>
 public abstract class BaseEnumTestData<T> : BaseTestData<T>
 	where T : unmanaged, Enum
 {
-	protected override IPrimitiveSerializer<T> ProduceSerializer() => new EnumSerializer<T>();
+	protected override IPrimitiveSerializer<T> ProduceSerializer() => EnumSerializer.SerializerFor<T>();
 }
 
 public class SByteEnumSerializerTestData : BaseEnumTestData<SByteEnum>

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -26,14 +26,16 @@ public class EnumSerializerTest
 		var (value, bytes) = testData;
 
 		// Serialize
-		Span<byte> buffer = stackalloc byte[bytes.Length];
-		serializer.Serialize(value, buffer);
-		var serializationResult = buffer.ToArray();
+		Span<byte> nodeBytes = stackalloc byte[bytes.Length];
+		var writeBuffer = nodeBytes;
+		serializer.Serialize(value, ref writeBuffer);
+		var serializationResult = nodeBytes.ToArray();
 
 		serializationResult.Should().BeEquivalentTo(bytes);
 
 		// Deserialize
-		var deserializationResult = serializer.Deserialize(bytes);
+		var bytesSpan = new ReadOnlySpan<byte>(bytes);
+		var deserializationResult = serializer.Deserialize(ref bytesSpan);
 
 		deserializationResult.Should().BeEquivalentTo(value);
 	}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/GenerateTestEnums.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/GenerateTestEnums.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
+
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+/// This isn't actively used anywhere in the codebase,
+/// it is just the code used to generate the enums in TestEnums.cs, included for illustrative purposes.
+[SuppressMessage("ReSharper", "UnusedType.Global")]
+[SuppressMessage("ReSharper", "UnusedMember.Global")]
+public static class GenerateTestEnums
+{
+	private static readonly Dictionary<Type, (BigInteger Min, BigInteger Max)> types = new()
+	{
+		{ typeof(sbyte), (sbyte.MinValue, sbyte.MaxValue) },
+		{ typeof(byte), (byte.MinValue, byte.MaxValue) },
+		{ typeof(short), (short.MinValue, short.MaxValue) },
+		{ typeof(ushort), (ushort.MinValue, ushort.MaxValue) },
+		{ typeof(int), (int.MinValue, int.MaxValue) },
+		{ typeof(uint), (uint.MinValue, uint.MaxValue) },
+		{ typeof(long), (long.MinValue, long.MaxValue) },
+		{ typeof(ulong), (ulong.MinValue, ulong.MaxValue) },
+	};
+
+	public static void Generate()
+	{
+		var numberFormat = new NumberFormatInfo
+		{
+			NumberGroupSeparator = "_",
+			NumberGroupSizes = new[] { 3 },
+			NumberDecimalDigits = 0
+		};
+
+		foreach (var (type, (min, max)) in types)
+		{
+			var mid1Frac = Math.PI - 3;
+			var mid2Frac = Math.E - 2;
+
+			if (min < 0)
+			{
+				(mid1Frac, mid2Frac) = (1 - mid2Frac, 1 - mid1Frac);
+			}
+
+			var mid1 = Math.Ceiling((double)(max - min) * mid1Frac + (double)min);
+			var mid2 = Math.Ceiling((double)(max - min) * mid2Frac + (double)min);
+
+			Console.WriteLine($"public enum {type.Name}Enum : {type.FullName}");
+			Console.WriteLine("{");
+			Console.WriteLine($"\tMin = {min.ToString("n", numberFormat)},");
+			Console.WriteLine($"\tMid1 = {mid1.ToString("n", numberFormat)},     // ((Max - Min) * {Math.Round(mid1Frac, 5)}) + Min");
+			Console.WriteLine($"\tMid2 = {mid2.ToString("n", numberFormat)},     // ((Max - Min) * {Math.Round(mid2Frac, 5)}) + Min");
+			Console.WriteLine($"\tMax = {max.ToString("n", numberFormat)},");
+			Console.WriteLine("}\n");
+		}
+	}
+}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TestEnums.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TestEnums.cs
@@ -1,0 +1,73 @@
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+// For unsigned
+// Mid1 = ((Max - Min) * (Math.PI - 3)) + Min
+// Mid2 = ((Max - Min) * (Math.E - 2)) + Min
+
+// For signed
+// Mid1 = ((Max - Min) * (1 - (Math.E - 2))) + Min
+// Mid2 = ((Max - Min) * (1 - (Math.PI - 3))) + Min
+
+public enum SByteEnum : sbyte
+{
+	Min = -128,
+	Mid1 = -56, // ((Max - Min) * 0.28172) + Min
+	Mid2 = 91,  // ((Max - Min) * 0.85841) + Min
+	Max = 127,
+}
+
+public enum ByteEnum : byte
+{
+	Min = 0,
+	Mid1 = 37,  // ((Max - Min) * 0.14159) + Min
+	Mid2 = 184, // ((Max - Min) * 0.71828) + Min
+	Max = 255,
+}
+
+public enum Int16Enum : short
+{
+	Min = -32_768,
+	Mid1 = -14_305, // ((Max - Min) * 0.28172) + Min
+	Mid2 = 23_488,  // ((Max - Min) * 0.85841) + Min
+	Max = 32_767,
+}
+
+public enum UInt16Enum : ushort
+{
+	Min = 0,
+	Mid1 = 9_280,  // ((Max - Min) * 0.14159) + Min
+	Mid2 = 47_073, // ((Max - Min) * 0.71828) + Min
+	Max = 65_535,
+}
+
+public enum Int32Enum : int
+{
+	Min = -2_147_483_648,
+	Mid1 = -937_513_314,  // ((Max - Min) * 0.28172) + Min
+	Mid2 = 1_539_347_831, // ((Max - Min) * 0.85841) + Min
+	Max = 2_147_483_647,
+}
+
+public enum UInt32Enum : uint
+{
+	Min = 0,
+	Mid1 = 608_135_817,   // ((Max - Min) * 0.14159) + Min
+	Mid2 = 3_084_996_962, // ((Max - Min) * 0.71828) + Min
+	Max = 4_294_967_295,
+}
+
+public enum Int64Enum : long
+{
+	Min = -9_223_372_036_854_775_808,
+	Mid1 = -4_026_589_025_525_376_000, // ((Max - Min) * 0.28172) + Min
+	Mid2 = 6_611_448_593_366_448_128,  // ((Max - Min) * 0.85841) + Min
+	Max = 9_223_372_036_854_775_807,
+}
+
+public enum UInt64Enum : ulong
+{
+	Min = 0,
+	Mid1 = 2_611_923_443_488_325_120,  // ((Max - Min) * 0.14159) + Min
+	Mid2 = 13_249_961_062_380_148_736, // ((Max - Min) * 0.71828) + Min
+	Max = 18_446_744_073_709_551_615,
+}


### PR DESCRIPTION
A primitive serializer is responsible for serializing a single data type into byte format. This is the most atomic form of serializer and many primitive serializers can be composed into a blob node serializer to serialize the pieces of data that make up the blob.