### PR TITLE
Use abstract base class for primitive serializer tests

### DIFF
--- a/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/IPrimitiveSerializer.cs
@@ -19,9 +19,13 @@ public interface IPrimitiveSerializer<T>
 	public int ByteCountForValue(T value);
 
 	/// Serializes the given value into the start of the given byte buffer,
-	/// then slices the buffer to the remaining space after the write
+	/// then slices the buffer to the remaining space after the write.
+	/// <exception cref="ArgumentOutOfRangeException">thrown when the given <paramref name="buffer"/>
+	/// is too small to contain the serialized encoding of the given value.</exception>
 	public void Serialize(T value, ref Span<byte> buffer);
 
 	/// Deserializes a value from the given byte buffer, then slices the buffer to the remaining unread space
+	/// <exception cref="ArgumentOutOfRangeException">thrown when the given <paramref name="buffer"/>
+	/// is too small to read a value of type <typeparamref name="T"/> from.</exception>
 	public T Deserialize(ref ReadOnlySpan<byte> buffer);
 }

--- a/tests/PandoTests/PandoTests.csproj
+++ b/tests/PandoTests/PandoTests.csproj
@@ -1,14 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-
 		<IsPackable>false</IsPackable>
-
 		<Nullable>enable</Nullable>
-
-		<LangVersion>10</LangVersion>
-
+		<LangVersion>preview</LangVersion>
 		<TargetFramework>net6.0</TargetFramework>
+		<EnablePreviewFeatures>True</EnablePreviewFeatures> <!-- For abstract static interface members -->
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/PandoTests/PandoTests.csproj
+++ b/tests/PandoTests/PandoTests.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="NSubstitute" Version="4.2.2" />
 		<PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit" Version="2.4.0" /> <!-- 2.4.1 has a bug that prevents abstract test classes from working correctly -->
 		<PackageReference Include="xunit.runner.console" Version="2.4.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
@@ -5,29 +5,57 @@ using Xunit;
 
 namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
 
+/// A base class declaring a number of tests that all primitive serializers should pass
 public abstract class BaseSerializerTest<T>
 {
+	/// Used to overallocate serialization/deserialization buffers so that we can verify that the serializers chop off the appropriate number of bytes.
+	private const int EXTRA_BUFFER_SPACE = 1;
+
+	/// Provides the serializer under test
 	protected abstract IPrimitiveSerializer<T> Serializer { get; }
 
+	/// <summary>
+	/// <para>Verifies the following about <see cref="IPrimitiveSerializer{T}.Serialize"/>:</para>
+	///   1. That it writes the correct bytes to the given buffer.<br />
+	///   2. That it appropriately chops the write span to the remaining space after the write.
+	/// </summary>
 	[Theory]
 	[MemberData(nameof(TestDataProviderPlaceholders.SerializationTestData))]
 	public virtual void Serialize_should_produce_correct_bytes(T value, byte[] bytes)
 	{
-		Span<byte> nodeBytes = stackalloc byte[bytes.Length];
+		Span<byte> nodeBytes = stackalloc byte[bytes.Length + EXTRA_BUFFER_SPACE];
 		var writeBuffer = nodeBytes;
-		Serializer.Serialize(value, ref writeBuffer);
-		var serializationResult = nodeBytes.ToArray();
 
+		Serializer.Serialize(value, ref writeBuffer);
+
+		var serializationResult = nodeBytes[..bytes.Length].ToArray();
 		serializationResult.Should().BeEquivalentTo(bytes);
+		writeBuffer.Length.Should()
+			.Be(EXTRA_BUFFER_SPACE,
+				"because the serializer is expected to chop off the written-to slice from the write buffer"
+			);
 	}
 
+	/// <summary>
+	/// <para>Verifies the following about <see cref="IPrimitiveSerializer{T}.Deserialize"/>:</para>
+	///   1. That it reads the correct value from the given buffer.<br />
+	///   2. That it appropriately chops the read span to the remaining unread space after the read.
+	/// </summary>
 	[Theory]
 	[MemberData(nameof(TestDataProviderPlaceholders.SerializationTestData))]
 	public virtual void Deserialize_should_produce_correct_value(T value, byte[] bytes)
 	{
-		var bytesSpan = new ReadOnlySpan<byte>(bytes);
-		var deserializationResult = Serializer.Deserialize(ref bytesSpan);
+		Span<byte> nodeBytes = new byte[bytes.Length + EXTRA_BUFFER_SPACE];
+		bytes.CopyTo(nodeBytes);
+		ReadOnlySpan<byte> readBuffer = nodeBytes;
+
+		var deserializationResult = Serializer.Deserialize(ref readBuffer);
+
 		deserializationResult.Should().BeEquivalentTo(value);
+		readBuffer.Length.Should()
+			.Be(EXTRA_BUFFER_SPACE,
+				"because the serializer is expected to chop off the read-from slice from the read buffer"
+			);
 	}
 
 	[Theory]

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
@@ -1,0 +1,35 @@
+using System;
+using FluentAssertions;
+using Pando.Serialization.PrimitiveSerializers;
+using Xunit;
+
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+public abstract class BaseSerializerTest<T>
+{
+	protected abstract IPrimitiveSerializer<T> Serializer { get; }
+
+	private TheoryData<T, byte[]> TestData() =>
+		throw new NotImplementedException("This is just a placeholder for the test data source that will be implemented by descendants");
+
+	[Theory]
+	[MemberData(nameof(TestData))]
+	public virtual void Should_produce_correct_bytes(T value, byte[] bytes)
+	{
+		Span<byte> nodeBytes = stackalloc byte[bytes.Length];
+		var writeBuffer = nodeBytes;
+		Serializer.Serialize(value, ref writeBuffer);
+		var serializationResult = nodeBytes.ToArray();
+
+		serializationResult.Should().BeEquivalentTo(bytes);
+	}
+
+	[Theory]
+	[MemberData(nameof(TestData))]
+	public virtual void Should_produce_correct_value(T value, byte[] bytes)
+	{
+		var bytesSpan = new ReadOnlySpan<byte>(bytes);
+		var deserializationResult = Serializer.Deserialize(ref bytesSpan);
+		deserializationResult.Should().BeEquivalentTo(value);
+	}
+}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
@@ -58,6 +58,78 @@ public abstract class BaseSerializerTest<T>
 			);
 	}
 
+	/// <summary>
+	/// <para>Verifies the following about <see cref="IPrimitiveSerializer{T}.Serialize"/>:</para>
+	///   1. That it will throw an <see cref="ArgumentOutOfRangeException"/> if the given buffer is smaller than required for the given value.<br />
+	///   2. That when the buffer is too small, it does not resize the given span.
+	/// </summary>
+	[Theory]
+	[MemberData(nameof(TestDataProviderPlaceholders.SerializeUndersizedBufferTestData))]
+	public virtual void Serialize_should_throw_when_buffer_is_too_small(T value, int expectedSize)
+	{
+		var beforeBufferSize = expectedSize - 1;
+		int? afterBufferSize = null;
+
+		Serializer.Invoking(s =>
+				{
+					Span<byte> undersizedBuffer = new byte[beforeBufferSize];
+					try
+					{
+						s.Serialize(value, ref undersizedBuffer);
+					}
+					finally
+					{
+						afterBufferSize = undersizedBuffer.Length;
+					}
+				}
+			)
+			.Should()
+			.Throw<ArgumentOutOfRangeException>();
+
+		afterBufferSize.Should()
+			.Be(beforeBufferSize,
+				"because when the buffer is too small, the serializer should not modify the passed in buffer reference"
+			);
+	}
+
+	/// <summary>
+	/// <para>Verifies the following about <see cref="IPrimitiveSerializer{T}.Deserialize"/>:</para>
+	///   1. That it will throw an <see cref="ArgumentOutOfRangeException"/> if the given buffer is smaller than the size of the deserialized type.<br />
+	///   2. That when the buffer is too small, it does not resize the given span.
+	/// </summary>
+	[Theory]
+	[MemberData(nameof(TestDataProviderPlaceholders.DeserializeUndersizedBufferTestData))]
+	public virtual void Deserialize_should_throw_when_buffer_is_too_small(byte[] undersizedBuffer)
+	{
+		var beforeBufferSize = undersizedBuffer.Length;
+		int? afterBufferSize = null;
+
+		Serializer.Invoking(s =>
+				{
+					var bufferSpan = new ReadOnlySpan<byte>(undersizedBuffer);
+
+					try
+					{
+						s.Deserialize(ref bufferSpan);
+					}
+					finally
+					{
+						afterBufferSize = bufferSpan.Length;
+					}
+				}
+			)
+			.Should()
+			.Throw<ArgumentOutOfRangeException>();
+
+		afterBufferSize.Should()
+			.Be(beforeBufferSize,
+				"because when the buffer is too small, the serializer should not modify the passed in buffer reference"
+			);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="IPrimitiveSerializer{T}.ByteCount"/> returns the appropriate value.
+	/// </summary>
 	[Theory]
 	[MemberData(nameof(TestDataProviderPlaceholders.ByteCountTestData))]
 	public virtual void ByteCount_should_return_correct_size(int? expectedSize)
@@ -69,6 +141,12 @@ public abstract class BaseSerializerTest<T>
 internal static class TestDataProviderPlaceholders
 {
 	public static void SerializationTestData() =>
+		throw new NotImplementedException("This is just a placeholder for the test data source that will be implemented by descendants");
+
+	public static void SerializeUndersizedBufferTestData() =>
+		throw new NotImplementedException("This is just a placeholder for the test data source that will be implemented by descendants");
+
+	public static void DeserializeUndersizedBufferTestData() =>
 		throw new NotImplementedException("This is just a placeholder for the test data source that will be implemented by descendants");
 
 	public static void ByteCountTestData() =>

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
@@ -60,7 +60,8 @@ public abstract class BaseSerializerTest<T>
 
 	/// <summary>
 	/// <para>Verifies the following about <see cref="IPrimitiveSerializer{T}.Serialize"/>:</para>
-	///   1. That it will throw an <see cref="ArgumentOutOfRangeException"/> if the given buffer is smaller than required for the given value.<br />
+	///   1. That it will throw an <see cref="ArgumentOutOfRangeException"/> if the given buffer is smaller
+	///			than required for the given value.<br />
 	///   2. That when the buffer is too small, it does not resize the given span.
 	/// </summary>
 	[Theory]
@@ -94,9 +95,15 @@ public abstract class BaseSerializerTest<T>
 
 	/// <summary>
 	/// <para>Verifies the following about <see cref="IPrimitiveSerializer{T}.Deserialize"/>:</para>
-	///   1. That it will throw an <see cref="ArgumentOutOfRangeException"/> if the given buffer is smaller than the size of the deserialized type.<br />
+	///   1. That it will throw an <see cref="ArgumentOutOfRangeException"/> if the given buffer is smaller
+	///			than the size of the deserialized type.<br />
 	///   2. That when the buffer is too small, it does not resize the given span.
 	/// </summary>
+	/// <remarks>
+	/// This is trivial for fixed size serializers, but for variable size serializers, whether or not the buffer is
+	/// undersized can depend on the contents of the buffer. For these cases the serializer must read from the buffer,
+	/// but must not chop the buffer in the case that the buffer is an incorrect size.
+	/// </remarks>
 	[Theory]
 	[MemberData(nameof(TestDataProviderPlaceholders.DeserializeUndersizedBufferTestData))]
 	public virtual void Deserialize_should_throw_when_buffer_is_too_small(byte[] undersizedBuffer)

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
@@ -9,12 +9,9 @@ public abstract class BaseSerializerTest<T>
 {
 	protected abstract IPrimitiveSerializer<T> Serializer { get; }
 
-	private TheoryData<T, byte[]> TestData() =>
-		throw new NotImplementedException("This is just a placeholder for the test data source that will be implemented by descendants");
-
 	[Theory]
-	[MemberData(nameof(TestData))]
-	public virtual void Should_produce_correct_bytes(T value, byte[] bytes)
+	[MemberData(nameof(TestDataProviderPlaceholders.SerializationTestData))]
+	public virtual void Serialize_should_produce_correct_bytes(T value, byte[] bytes)
 	{
 		Span<byte> nodeBytes = stackalloc byte[bytes.Length];
 		var writeBuffer = nodeBytes;
@@ -25,11 +22,27 @@ public abstract class BaseSerializerTest<T>
 	}
 
 	[Theory]
-	[MemberData(nameof(TestData))]
-	public virtual void Should_produce_correct_value(T value, byte[] bytes)
+	[MemberData(nameof(TestDataProviderPlaceholders.SerializationTestData))]
+	public virtual void Deserialize_should_produce_correct_value(T value, byte[] bytes)
 	{
 		var bytesSpan = new ReadOnlySpan<byte>(bytes);
 		var deserializationResult = Serializer.Deserialize(ref bytesSpan);
 		deserializationResult.Should().BeEquivalentTo(value);
 	}
+
+	[Theory]
+	[MemberData(nameof(TestDataProviderPlaceholders.ByteCountTestData))]
+	public virtual void ByteCount_should_return_correct_size(int? expectedSize)
+	{
+		Serializer.ByteCount.Should().Be(expectedSize);
+	}
+}
+
+internal static class TestDataProviderPlaceholders
+{
+	public static void SerializationTestData() =>
+		throw new NotImplementedException("This is just a placeholder for the test data source that will be implemented by descendants");
+
+	public static void ByteCountTestData() =>
+		throw new NotImplementedException("This is just a placeholder for the test data source that will be implemented by descendants");
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -1,145 +1,117 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using FluentAssertions;
 using Pando.Serialization.PrimitiveSerializers;
 using Xunit;
 
+// Rider doesn't detect subclasses of BaseSerializerTest as being used, because they inherit their test methods
+// ReSharper disable UnusedType.Global
+// ReSharper disable UnusedMember.Global
+
 namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
 
-public record struct TestData<T>(T Value, byte[] Bytes);
-
-public class EnumSerializerTest
+/// A collection of test classes for every kind of enum serializer
+/// <see cref="BaseSerializerTest{T}"/>
+public class EnumSerializerTests
 {
-	[Theory]
-	[ClassData(typeof(SByteEnumSerializerTestData))]
-	[ClassData(typeof(ByteEnumSerializerTestData))]
-	[ClassData(typeof(Int16EnumSerializerTestData))]
-	[ClassData(typeof(UInt16EnumSerializerTestData))]
-	[ClassData(typeof(Int32EnumSerializerTestData))]
-	[ClassData(typeof(UInt32EnumSerializerTestData))]
-	[ClassData(typeof(Int64EnumSerializerTestData))]
-	[ClassData(typeof(UInt64EnumSerializerTestData))]
-	public void Serialize_Deserialize<T>(TestData<T> testData, IPrimitiveSerializer<T> serializer)
+	public class SByteEnumSerializerTests : BaseSerializerTest<SByteEnum>
 	{
-		var (value, bytes) = testData;
+		protected override IPrimitiveSerializer<SByteEnum> Serializer => EnumSerializer.SerializerFor<SByteEnum>();
 
-		// Serialize
-		Span<byte> nodeBytes = stackalloc byte[bytes.Length];
-		var writeBuffer = nodeBytes;
-		serializer.Serialize(value, ref writeBuffer);
-		var serializationResult = nodeBytes.ToArray();
-
-		serializationResult.Should().BeEquivalentTo(bytes);
-
-		// Deserialize
-		var bytesSpan = new ReadOnlySpan<byte>(bytes);
-		var deserializationResult = serializer.Deserialize(ref bytesSpan);
-
-		deserializationResult.Should().BeEquivalentTo(value);
+		public static TheoryData<SByteEnum, byte[]> TestData => new()
+		{
+			{ SByteEnum.Min, new byte[] { 0x80 } },
+			{ SByteEnum.Mid1, new byte[] { 0xC8 } },
+			{ SByteEnum.Mid2, new byte[] { 0x5B } },
+			{ SByteEnum.Max, new byte[] { 0x7F } },
+		};
 	}
-}
 
-public abstract class BaseTestData<T> : IEnumerable<object[]>
-{
-	protected abstract IPrimitiveSerializer<T> ProduceSerializer();
-	protected abstract IEnumerable<TestData<T>> ProduceTestData();
-
-	public IEnumerator<object[]> GetEnumerator() => ProduceTestData().Select(td => new object[] { td, ProduceSerializer() }).GetEnumerator();
-	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-}
-
-public abstract class BaseEnumTestData<T> : BaseTestData<T>
-	where T : unmanaged, Enum
-{
-	protected override IPrimitiveSerializer<T> ProduceSerializer() => EnumSerializer.SerializerFor<T>();
-}
-
-public class SByteEnumSerializerTestData : BaseEnumTestData<SByteEnum>
-{
-	protected override IEnumerable<TestData<SByteEnum>> ProduceTestData() => new List<TestData<SByteEnum>>
+	public class ByteEnumSerializerTests : BaseSerializerTest<ByteEnum>
 	{
-		new(SByteEnum.Min, new byte[] { 0x80 }),
-		new(SByteEnum.Mid1, new byte[] { 0xC8 }),
-		new(SByteEnum.Mid2, new byte[] { 0x5B }),
-		new(SByteEnum.Max, new byte[] { 0x7F }),
-	};
-}
+		protected override IPrimitiveSerializer<ByteEnum> Serializer => EnumSerializer.SerializerFor<ByteEnum>();
 
-public class ByteEnumSerializerTestData : BaseEnumTestData<ByteEnum>
-{
-	protected override IEnumerable<TestData<ByteEnum>> ProduceTestData() => new List<TestData<ByteEnum>>
-	{
-		new(ByteEnum.Min, new byte[] { 0x00 }),
-		new(ByteEnum.Mid1, new byte[] { 0x25 }),
-		new(ByteEnum.Mid2, new byte[] { 0xB8 }),
-		new(ByteEnum.Max, new byte[] { 0xFF }),
-	};
-}
+		public static TheoryData<ByteEnum, byte[]> TestData => new()
+		{
+			{ ByteEnum.Min, new byte[] { 0x00 } },
+			{ ByteEnum.Mid1, new byte[] { 0x25 } },
+			{ ByteEnum.Mid2, new byte[] { 0xB8 } },
+			{ ByteEnum.Max, new byte[] { 0xFF } },
+		};
+	}
 
-public class Int16EnumSerializerTestData : BaseEnumTestData<Int16Enum>
-{
-	protected override IEnumerable<TestData<Int16Enum>> ProduceTestData() => new List<TestData<Int16Enum>>
+	public class Int16EnumSerializerTests : BaseSerializerTest<Int16Enum>
 	{
-		new(Int16Enum.Min, new byte[] { 0x00, 0x80 }),
-		new(Int16Enum.Mid1, new byte[] { 0x1F, 0xC8 }),
-		new(Int16Enum.Mid2, new byte[] { 0xC0, 0x5B }),
-		new(Int16Enum.Max, new byte[] { 0xFF, 0x7F }),
-	};
-}
+		protected override IPrimitiveSerializer<Int16Enum> Serializer => EnumSerializer.SerializerFor<Int16Enum>();
 
-public class UInt16EnumSerializerTestData : BaseEnumTestData<UInt16Enum>
-{
-	protected override IEnumerable<TestData<UInt16Enum>> ProduceTestData() => new List<TestData<UInt16Enum>>
-	{
-		new(UInt16Enum.Min, new byte[] { 0x00, 0x00 }),
-		new(UInt16Enum.Mid1, new byte[] { 0x40, 0x24 }),
-		new(UInt16Enum.Mid2, new byte[] { 0xE1, 0xB7 }),
-		new(UInt16Enum.Max, new byte[] { 0xFF, 0xFF }),
-	};
-}
+		public static TheoryData<Int16Enum, byte[]> TestData => new()
+		{
+			{ Int16Enum.Min, new byte[] { 0x00, 0x80 } },
+			{ Int16Enum.Mid1, new byte[] { 0x1F, 0xC8 } },
+			{ Int16Enum.Mid2, new byte[] { 0xC0, 0x5B } },
+			{ Int16Enum.Max, new byte[] { 0xFF, 0x7F } },
+		};
+	}
 
-public class Int32EnumSerializerTestData : BaseEnumTestData<Int32Enum>
-{
-	protected override IEnumerable<TestData<Int32Enum>> ProduceTestData() => new List<TestData<Int32Enum>>
+	public class UInt16EnumSerializerTests : BaseSerializerTest<UInt16Enum>
 	{
-		new(Int32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x80 }),
-		new(Int32Enum.Mid1, new byte[] { 0x9E, 0xAE, 0x1E, 0xC8 }),
-		new(Int32Enum.Mid2, new byte[] { 0x77, 0x95, 0xC0, 0x5B }),
-		new(Int32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F }),
-	};
-}
+		protected override IPrimitiveSerializer<UInt16Enum> Serializer => EnumSerializer.SerializerFor<UInt16Enum>();
 
-public class UInt32EnumSerializerTestData : BaseEnumTestData<UInt32Enum>
-{
-	protected override IEnumerable<TestData<UInt32Enum>> ProduceTestData() => new List<TestData<UInt32Enum>>
-	{
-		new(UInt32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00 }),
-		new(UInt32Enum.Mid1, new byte[] { 0x89, 0x6A, 0x3F, 0x24 }),
-		new(UInt32Enum.Mid2, new byte[] { 0x62, 0x51, 0xE1, 0xB7 }),
-		new(UInt32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }),
-	};
-}
+		public static TheoryData<UInt16Enum, byte[]> TestData => new()
+		{
+			{ UInt16Enum.Min, new byte[] { 0x00, 0x00 } },
+			{ UInt16Enum.Mid1, new byte[] { 0x40, 0x24 } },
+			{ UInt16Enum.Mid2, new byte[] { 0xE1, 0xB7 } },
+			{ UInt16Enum.Max, new byte[] { 0xFF, 0xFF } },
+		};
+	}
 
-public class Int64EnumSerializerTestData : BaseEnumTestData<Int64Enum>
-{
-	protected override IEnumerable<TestData<Int64Enum>> ProduceTestData() => new List<TestData<Int64Enum>>
+	public class Int32EnumSerializerTests : BaseSerializerTest<Int32Enum>
 	{
-		new(Int64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 }),
-		new(Int64Enum.Mid1, new byte[] { 0x00, 0xDC, 0x12, 0x75, 0x9D, 0xAE, 0x1E, 0xC8 }),
-		new(Int64Enum.Mid2, new byte[] { 0x00, 0xF8, 0x5C, 0x7A, 0x77, 0x95, 0xC0, 0x5B }),
-		new(Int64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F }),
-	};
-}
+		protected override IPrimitiveSerializer<Int32Enum> Serializer => EnumSerializer.SerializerFor<Int32Enum>();
 
-public class UInt64EnumSerializerTestData : BaseEnumTestData<UInt64Enum>
-{
-	protected override IEnumerable<TestData<UInt64Enum>> ProduceTestData() => new List<TestData<UInt64Enum>>
+		public static TheoryData<Int32Enum, byte[]> TestData => new()
+		{
+			{ Int32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x80 } },
+			{ Int32Enum.Mid1, new byte[] { 0x9E, 0xAE, 0x1E, 0xC8 } },
+			{ Int32Enum.Mid2, new byte[] { 0x77, 0x95, 0xC0, 0x5B } },
+			{ Int32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F } },
+		};
+	}
+
+	public class UInt32EnumSerializerTests : BaseSerializerTest<UInt32Enum>
 	{
-		new(UInt64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }),
-		new(UInt64Enum.Mid1, new byte[] { 0x00, 0xFE, 0xA2, 0x85, 0x88, 0x6A, 0x3F, 0x24 }),
-		new(UInt64Enum.Mid2, new byte[] { 0x00, 0x18, 0xED, 0x8A, 0x62, 0x51, 0xE1, 0xB7 }),
-		new(UInt64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF }),
-	};
+		protected override IPrimitiveSerializer<UInt32Enum> Serializer => EnumSerializer.SerializerFor<UInt32Enum>();
+
+		public static TheoryData<UInt32Enum, byte[]> TestData => new()
+		{
+			{ UInt32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00 } },
+			{ UInt32Enum.Mid1, new byte[] { 0x89, 0x6A, 0x3F, 0x24 } },
+			{ UInt32Enum.Mid2, new byte[] { 0x62, 0x51, 0xE1, 0xB7 } },
+			{ UInt32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF } },
+		};
+	}
+
+	public class Int64EnumSerializerTests : BaseSerializerTest<Int64Enum>
+	{
+		protected override IPrimitiveSerializer<Int64Enum> Serializer => EnumSerializer.SerializerFor<Int64Enum>();
+
+		public static TheoryData<Int64Enum, byte[]> TestData => new()
+		{
+			{ Int64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 } },
+			{ Int64Enum.Mid1, new byte[] { 0x00, 0xDC, 0x12, 0x75, 0x9D, 0xAE, 0x1E, 0xC8 } },
+			{ Int64Enum.Mid2, new byte[] { 0x00, 0xF8, 0x5C, 0x7A, 0x77, 0x95, 0xC0, 0x5B } },
+			{ Int64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F } },
+		};
+	}
+
+	public class UInt64EnumSerializerTests : BaseSerializerTest<UInt64Enum>
+	{
+		protected override IPrimitiveSerializer<UInt64Enum> Serializer => EnumSerializer.SerializerFor<UInt64Enum>();
+
+		public static TheoryData<UInt64Enum, byte[]> TestData => new()
+		{
+			{ UInt64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+			{ UInt64Enum.Mid1, new byte[] { 0x00, 0xFE, 0xA2, 0x85, 0x88, 0x6A, 0x3F, 0x24 } },
+			{ UInt64Enum.Mid2, new byte[] { 0x00, 0x18, 0xED, 0x8A, 0x62, 0x51, 0xE1, 0xB7 } },
+			{ UInt64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
+		};
+	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -12,7 +12,7 @@ namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
 /// <see cref="BaseSerializerTest{T}"/>
 public class EnumSerializerTests
 {
-	public class SByteEnumSerializerTests : BaseSerializerTest<SByteEnum>
+	public class SByteEnumSerializerTests : BaseSerializerTest<SByteEnum>, ISerializerTestData<SByteEnum>
 	{
 		private const int EXPECTED_SIZE = sizeof(sbyte);
 
@@ -26,12 +26,14 @@ public class EnumSerializerTests
 			{ SByteEnum.Max, new byte[] { 0x7F } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<SByteEnum, int> SerializeUndersizedBufferTestData => new() { { SByteEnum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<SByteEnum, int> ByteCountForValueTestData => new() { { SByteEnum.Min, EXPECTED_SIZE } };
 	}
 
-	public class ByteEnumSerializerTests : BaseSerializerTest<ByteEnum>
+	public class ByteEnumSerializerTests : BaseSerializerTest<ByteEnum>, ISerializerTestData<ByteEnum>
 	{
 		private const int EXPECTED_SIZE = sizeof(byte);
 
@@ -45,12 +47,14 @@ public class EnumSerializerTests
 			{ ByteEnum.Max, new byte[] { 0xFF } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<ByteEnum, int> SerializeUndersizedBufferTestData => new() { { ByteEnum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<ByteEnum, int> ByteCountForValueTestData => new() { { ByteEnum.Min, EXPECTED_SIZE } };
 	}
 
-	public class Int16EnumSerializerTests : BaseSerializerTest<Int16Enum>
+	public class Int16EnumSerializerTests : BaseSerializerTest<Int16Enum>, ISerializerTestData<Int16Enum>
 	{
 		private const int EXPECTED_SIZE = sizeof(short);
 
@@ -64,12 +68,14 @@ public class EnumSerializerTests
 			{ Int16Enum.Max, new byte[] { 0xFF, 0x7F } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<Int16Enum, int> SerializeUndersizedBufferTestData => new() { { Int16Enum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<Int16Enum, int> ByteCountForValueTestData => new() { { Int16Enum.Min, EXPECTED_SIZE } };
 	}
 
-	public class UInt16EnumSerializerTests : BaseSerializerTest<UInt16Enum>
+	public class UInt16EnumSerializerTests : BaseSerializerTest<UInt16Enum>, ISerializerTestData<UInt16Enum>
 	{
 		private const int EXPECTED_SIZE = sizeof(ushort);
 
@@ -83,12 +89,14 @@ public class EnumSerializerTests
 			{ UInt16Enum.Max, new byte[] { 0xFF, 0xFF } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<UInt16Enum, int> SerializeUndersizedBufferTestData => new() { { UInt16Enum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<UInt16Enum, int> ByteCountForValueTestData => new() { { UInt16Enum.Min, EXPECTED_SIZE } };
 	}
 
-	public class Int32EnumSerializerTests : BaseSerializerTest<Int32Enum>
+	public class Int32EnumSerializerTests : BaseSerializerTest<Int32Enum>, ISerializerTestData<Int32Enum>
 	{
 		private const int EXPECTED_SIZE = sizeof(int);
 
@@ -102,12 +110,14 @@ public class EnumSerializerTests
 			{ Int32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<Int32Enum, int> SerializeUndersizedBufferTestData => new() { { Int32Enum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<Int32Enum, int> ByteCountForValueTestData => new() { { Int32Enum.Min, EXPECTED_SIZE } };
 	}
 
-	public class UInt32EnumSerializerTests : BaseSerializerTest<UInt32Enum>
+	public class UInt32EnumSerializerTests : BaseSerializerTest<UInt32Enum>, ISerializerTestData<UInt32Enum>
 	{
 		private const int EXPECTED_SIZE = sizeof(uint);
 
@@ -121,12 +131,14 @@ public class EnumSerializerTests
 			{ UInt32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<UInt32Enum, int> SerializeUndersizedBufferTestData => new() { { UInt32Enum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<UInt32Enum, int> ByteCountForValueTestData => new() { { UInt32Enum.Min, EXPECTED_SIZE } };
 	}
 
-	public class Int64EnumSerializerTests : BaseSerializerTest<Int64Enum>
+	public class Int64EnumSerializerTests : BaseSerializerTest<Int64Enum>, ISerializerTestData<Int64Enum>
 	{
 		private const int EXPECTED_SIZE = sizeof(long);
 
@@ -140,12 +152,14 @@ public class EnumSerializerTests
 			{ Int64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<Int64Enum, int> SerializeUndersizedBufferTestData => new() { { Int64Enum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<Int64Enum, int> ByteCountForValueTestData => new() { { Int64Enum.Min, EXPECTED_SIZE } };
 	}
 
-	public class UInt64EnumSerializerTests : BaseSerializerTest<UInt64Enum>
+	public class UInt64EnumSerializerTests : BaseSerializerTest<UInt64Enum>, ISerializerTestData<UInt64Enum>
 	{
 		private const int EXPECTED_SIZE = sizeof(ulong);
 
@@ -159,8 +173,10 @@ public class EnumSerializerTests
 			{ UInt64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
 		};
 
-		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
 		public static TheoryData<UInt64Enum, int> SerializeUndersizedBufferTestData => new() { { UInt64Enum.Min, EXPECTED_SIZE } };
 		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
+
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<UInt64Enum, int> ByteCountForValueTestData => new() { { UInt64Enum.Min, EXPECTED_SIZE } };
 	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Pando.Serialization.PrimitiveSerializers;
 using Xunit;
 
@@ -13,6 +14,8 @@ public class EnumSerializerTests
 {
 	public class SByteEnumSerializerTests : BaseSerializerTest<SByteEnum>
 	{
+		private const int EXPECTED_SIZE = sizeof(sbyte);
+
 		protected override IPrimitiveSerializer<SByteEnum> Serializer => EnumSerializer.SerializerFor<SByteEnum>();
 
 		public static TheoryData<SByteEnum, byte[]> SerializationTestData => new()
@@ -23,11 +26,15 @@ public class EnumSerializerTests
 			{ SByteEnum.Max, new byte[] { 0x7F } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(sbyte) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<SByteEnum, int> SerializeUndersizedBufferTestData => new() { { SByteEnum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 
 	public class ByteEnumSerializerTests : BaseSerializerTest<ByteEnum>
 	{
+		private const int EXPECTED_SIZE = sizeof(byte);
+
 		protected override IPrimitiveSerializer<ByteEnum> Serializer => EnumSerializer.SerializerFor<ByteEnum>();
 
 		public static TheoryData<ByteEnum, byte[]> SerializationTestData => new()
@@ -38,11 +45,15 @@ public class EnumSerializerTests
 			{ ByteEnum.Max, new byte[] { 0xFF } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(byte) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<ByteEnum, int> SerializeUndersizedBufferTestData => new() { { ByteEnum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 
 	public class Int16EnumSerializerTests : BaseSerializerTest<Int16Enum>
 	{
+		private const int EXPECTED_SIZE = sizeof(short);
+
 		protected override IPrimitiveSerializer<Int16Enum> Serializer => EnumSerializer.SerializerFor<Int16Enum>();
 
 		public static TheoryData<Int16Enum, byte[]> SerializationTestData => new()
@@ -53,11 +64,15 @@ public class EnumSerializerTests
 			{ Int16Enum.Max, new byte[] { 0xFF, 0x7F } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(short) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<Int16Enum, int> SerializeUndersizedBufferTestData => new() { { Int16Enum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 
 	public class UInt16EnumSerializerTests : BaseSerializerTest<UInt16Enum>
 	{
+		private const int EXPECTED_SIZE = sizeof(ushort);
+
 		protected override IPrimitiveSerializer<UInt16Enum> Serializer => EnumSerializer.SerializerFor<UInt16Enum>();
 
 		public static TheoryData<UInt16Enum, byte[]> SerializationTestData => new()
@@ -68,11 +83,15 @@ public class EnumSerializerTests
 			{ UInt16Enum.Max, new byte[] { 0xFF, 0xFF } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(ushort) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<UInt16Enum, int> SerializeUndersizedBufferTestData => new() { { UInt16Enum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 
 	public class Int32EnumSerializerTests : BaseSerializerTest<Int32Enum>
 	{
+		private const int EXPECTED_SIZE = sizeof(int);
+
 		protected override IPrimitiveSerializer<Int32Enum> Serializer => EnumSerializer.SerializerFor<Int32Enum>();
 
 		public static TheoryData<Int32Enum, byte[]> SerializationTestData => new()
@@ -83,11 +102,15 @@ public class EnumSerializerTests
 			{ Int32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(int) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<Int32Enum, int> SerializeUndersizedBufferTestData => new() { { Int32Enum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 
 	public class UInt32EnumSerializerTests : BaseSerializerTest<UInt32Enum>
 	{
+		private const int EXPECTED_SIZE = sizeof(uint);
+
 		protected override IPrimitiveSerializer<UInt32Enum> Serializer => EnumSerializer.SerializerFor<UInt32Enum>();
 
 		public static TheoryData<UInt32Enum, byte[]> SerializationTestData => new()
@@ -98,11 +121,15 @@ public class EnumSerializerTests
 			{ UInt32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(uint) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<UInt32Enum, int> SerializeUndersizedBufferTestData => new() { { UInt32Enum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 
 	public class Int64EnumSerializerTests : BaseSerializerTest<Int64Enum>
 	{
+		private const int EXPECTED_SIZE = sizeof(long);
+
 		protected override IPrimitiveSerializer<Int64Enum> Serializer => EnumSerializer.SerializerFor<Int64Enum>();
 
 		public static TheoryData<Int64Enum, byte[]> SerializationTestData => new()
@@ -113,11 +140,15 @@ public class EnumSerializerTests
 			{ Int64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(long) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<Int64Enum, int> SerializeUndersizedBufferTestData => new() { { Int64Enum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 
 	public class UInt64EnumSerializerTests : BaseSerializerTest<UInt64Enum>
 	{
+		private const int EXPECTED_SIZE = sizeof(ulong);
+
 		protected override IPrimitiveSerializer<UInt64Enum> Serializer => EnumSerializer.SerializerFor<UInt64Enum>();
 
 		public static TheoryData<UInt64Enum, byte[]> SerializationTestData => new()
@@ -128,6 +159,8 @@ public class EnumSerializerTests
 			{ UInt64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
 		};
 
-		public static TheoryData<int> ByteCountTestData => new() { sizeof(ulong) };
+		public static TheoryData<int?> ByteCountTestData => new() { EXPECTED_SIZE };
+		public static TheoryData<UInt64Enum, int> SerializeUndersizedBufferTestData => new() { { UInt64Enum.Min, EXPECTED_SIZE } };
+		public static TheoryData<byte[]> DeserializeUndersizedBufferTestData => new() { Array.Empty<byte>() };
 	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -15,103 +15,119 @@ public class EnumSerializerTests
 	{
 		protected override IPrimitiveSerializer<SByteEnum> Serializer => EnumSerializer.SerializerFor<SByteEnum>();
 
-		public static TheoryData<SByteEnum, byte[]> TestData => new()
+		public static TheoryData<SByteEnum, byte[]> SerializationTestData => new()
 		{
 			{ SByteEnum.Min, new byte[] { 0x80 } },
 			{ SByteEnum.Mid1, new byte[] { 0xC8 } },
 			{ SByteEnum.Mid2, new byte[] { 0x5B } },
 			{ SByteEnum.Max, new byte[] { 0x7F } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(sbyte) };
 	}
 
 	public class ByteEnumSerializerTests : BaseSerializerTest<ByteEnum>
 	{
 		protected override IPrimitiveSerializer<ByteEnum> Serializer => EnumSerializer.SerializerFor<ByteEnum>();
 
-		public static TheoryData<ByteEnum, byte[]> TestData => new()
+		public static TheoryData<ByteEnum, byte[]> SerializationTestData => new()
 		{
 			{ ByteEnum.Min, new byte[] { 0x00 } },
 			{ ByteEnum.Mid1, new byte[] { 0x25 } },
 			{ ByteEnum.Mid2, new byte[] { 0xB8 } },
 			{ ByteEnum.Max, new byte[] { 0xFF } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(byte) };
 	}
 
 	public class Int16EnumSerializerTests : BaseSerializerTest<Int16Enum>
 	{
 		protected override IPrimitiveSerializer<Int16Enum> Serializer => EnumSerializer.SerializerFor<Int16Enum>();
 
-		public static TheoryData<Int16Enum, byte[]> TestData => new()
+		public static TheoryData<Int16Enum, byte[]> SerializationTestData => new()
 		{
 			{ Int16Enum.Min, new byte[] { 0x00, 0x80 } },
 			{ Int16Enum.Mid1, new byte[] { 0x1F, 0xC8 } },
 			{ Int16Enum.Mid2, new byte[] { 0xC0, 0x5B } },
 			{ Int16Enum.Max, new byte[] { 0xFF, 0x7F } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(short) };
 	}
 
 	public class UInt16EnumSerializerTests : BaseSerializerTest<UInt16Enum>
 	{
 		protected override IPrimitiveSerializer<UInt16Enum> Serializer => EnumSerializer.SerializerFor<UInt16Enum>();
 
-		public static TheoryData<UInt16Enum, byte[]> TestData => new()
+		public static TheoryData<UInt16Enum, byte[]> SerializationTestData => new()
 		{
 			{ UInt16Enum.Min, new byte[] { 0x00, 0x00 } },
 			{ UInt16Enum.Mid1, new byte[] { 0x40, 0x24 } },
 			{ UInt16Enum.Mid2, new byte[] { 0xE1, 0xB7 } },
 			{ UInt16Enum.Max, new byte[] { 0xFF, 0xFF } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(ushort) };
 	}
 
 	public class Int32EnumSerializerTests : BaseSerializerTest<Int32Enum>
 	{
 		protected override IPrimitiveSerializer<Int32Enum> Serializer => EnumSerializer.SerializerFor<Int32Enum>();
 
-		public static TheoryData<Int32Enum, byte[]> TestData => new()
+		public static TheoryData<Int32Enum, byte[]> SerializationTestData => new()
 		{
 			{ Int32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x80 } },
 			{ Int32Enum.Mid1, new byte[] { 0x9E, 0xAE, 0x1E, 0xC8 } },
 			{ Int32Enum.Mid2, new byte[] { 0x77, 0x95, 0xC0, 0x5B } },
 			{ Int32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0x7F } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(int) };
 	}
 
 	public class UInt32EnumSerializerTests : BaseSerializerTest<UInt32Enum>
 	{
 		protected override IPrimitiveSerializer<UInt32Enum> Serializer => EnumSerializer.SerializerFor<UInt32Enum>();
 
-		public static TheoryData<UInt32Enum, byte[]> TestData => new()
+		public static TheoryData<UInt32Enum, byte[]> SerializationTestData => new()
 		{
 			{ UInt32Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00 } },
 			{ UInt32Enum.Mid1, new byte[] { 0x89, 0x6A, 0x3F, 0x24 } },
 			{ UInt32Enum.Mid2, new byte[] { 0x62, 0x51, 0xE1, 0xB7 } },
 			{ UInt32Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(uint) };
 	}
 
 	public class Int64EnumSerializerTests : BaseSerializerTest<Int64Enum>
 	{
 		protected override IPrimitiveSerializer<Int64Enum> Serializer => EnumSerializer.SerializerFor<Int64Enum>();
 
-		public static TheoryData<Int64Enum, byte[]> TestData => new()
+		public static TheoryData<Int64Enum, byte[]> SerializationTestData => new()
 		{
 			{ Int64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80 } },
 			{ Int64Enum.Mid1, new byte[] { 0x00, 0xDC, 0x12, 0x75, 0x9D, 0xAE, 0x1E, 0xC8 } },
 			{ Int64Enum.Mid2, new byte[] { 0x00, 0xF8, 0x5C, 0x7A, 0x77, 0x95, 0xC0, 0x5B } },
 			{ Int64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(long) };
 	}
 
 	public class UInt64EnumSerializerTests : BaseSerializerTest<UInt64Enum>
 	{
 		protected override IPrimitiveSerializer<UInt64Enum> Serializer => EnumSerializer.SerializerFor<UInt64Enum>();
 
-		public static TheoryData<UInt64Enum, byte[]> TestData => new()
+		public static TheoryData<UInt64Enum, byte[]> SerializationTestData => new()
 		{
 			{ UInt64Enum.Min, new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
 			{ UInt64Enum.Mid1, new byte[] { 0x00, 0xFE, 0xA2, 0x85, 0x88, 0x6A, 0x3F, 0x24 } },
 			{ UInt64Enum.Mid2, new byte[] { 0x00, 0x18, 0xED, 0x8A, 0x62, 0x51, 0xE1, 0xB7 } },
 			{ UInt64Enum.Max, new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
 		};
+
+		public static TheoryData<int> ByteCountTestData => new() { sizeof(ulong) };
 	}
 }


### PR DESCRIPTION
This allows tests for each type of serializer to be listed separately in the test runner, since each type of serializer gets a sublcass of the abstract base test class.

Using abstract base classes with MemberData requires a xunit version downgrade from 2.4.1 -> 2.4.0 due to a bug in 2.4.1 that prevents it from working.

Also adds additional tests covering the whole IPrimitiveSerializer interface, exceptional cases, and post conditions (slicing the buffer after reading from/writing to it).

PANDO-39