### PR TITLE
PANDO-43: NullableSerializer tests

### DIFF
--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/EnumSerializerTest.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Buffers.Binary;
 using Pando.Serialization.PrimitiveSerializers;
 using Xunit;
 
@@ -23,23 +21,4 @@ public class EnumSerializerTests : BaseSerializerTest<TestEnum>, ISerializerTest
 public enum TestEnum : long
 {
 	Value = -36_240_869_367_020_799 // 0xFF_7F_3F_1F_0F_07_03_01
-}
-
-internal class SimpleLongSerializer : IPrimitiveSerializer<long>
-{
-	public int? ByteCount => sizeof(long);
-	public int ByteCountForValue(long value) => sizeof(long);
-
-	public void Serialize(long value, ref Span<byte> buffer)
-	{
-		BinaryPrimitives.WriteInt64BigEndian(buffer, value);
-		buffer = buffer[sizeof(ulong)..];
-	}
-
-	public long Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var result = BinaryPrimitives.ReadInt64BigEndian(buffer);
-		buffer = buffer[sizeof(ulong)..];
-		return result;
-	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/NullableSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/NullableSerializerTest.cs
@@ -1,0 +1,20 @@
+using Pando.Serialization.PrimitiveSerializers;
+using Xunit;
+
+// Rider doesn't detect subclasses of BaseSerializerTest as being used, because they inherit their test methods
+// ReSharper disable UnusedType.Global
+
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+public class NullableInt64SerializerTest : BaseSerializerTest<long?>, ISerializerTestData<long?>
+{
+	protected override IPrimitiveSerializer<long?> Serializer => new NullableSerializer<long>(new SimpleLongSerializer());
+
+	public static TheoryData<long?, byte[]> SerializationTestData => new()
+	{
+		{ null, new byte[] { 0 } },
+		{ long.MaxValue, new byte[] { 0x01, 0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
+	};
+
+	public static TheoryData<int?> ByteCountTestData => new() { null };
+}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/SimpleLongSerializer.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/SimpleLongSerializer.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Buffers.Binary;
+using Pando.Serialization.PrimitiveSerializers;
+
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+/// A simply implemented long serializer that serializes in big endian encoding
+/// <remarks>This exists to provide a very simple, self-contained serializer that upholds the
+/// IPrimitiveSerializer contract in as few lines as possible for testing.</remarks>
+internal class SimpleLongSerializer : IPrimitiveSerializer<long>
+{
+	public int? ByteCount => sizeof(long);
+	public int ByteCountForValue(long value) => sizeof(long);
+
+	public void Serialize(long value, ref Span<byte> buffer)
+	{
+		BinaryPrimitives.WriteInt64BigEndian(buffer, value);
+		buffer = buffer[sizeof(ulong)..];
+	}
+
+	public long Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var result = BinaryPrimitives.ReadInt64BigEndian(buffer);
+		buffer = buffer[sizeof(ulong)..];
+		return result;
+	}
+}


### PR DESCRIPTION
Adds tests for nullable serializer
Ensure nullable serializer upholds the IPrimitiveSerializer contract by not modifying the write/read buffers if the buffer is too small to continue
Fix some errors in the test code implementation to make sure that the tests work correctly for serializers that rely on the contents of the buffer to determine how much to read/write