### PR TITLE
PANDO-42: Add Time struct serializer tests

### DIFF
--- a/src/Pando/Serialization/PrimitiveSerializers/DateTimeToBinarySerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/DateTimeToBinarySerializer.cs
@@ -7,20 +7,20 @@ namespace Pando.Serialization.PrimitiveSerializers;
 /// Serializes/deserializes a <see cref="DateTime"/> via a <c>long</c> serializer
 /// to serialize the <c>DateTime</c>'s <see cref="DateTime.ToBinary"/> encoding.
 /// </summary>
-public class DateTimeUnixSerializer : IPrimitiveSerializer<DateTime>
+public class DateTimeToBinarySerializer : IPrimitiveSerializer<DateTime>
 {
-	/// <summary>A global default instance for <see cref="DateTimeUnixSerializer"/></summary>
-	public static DateTimeUnixSerializer Default { get; } = new();
+	/// <summary>A global default instance for <see cref="DateTimeToBinarySerializer"/></summary>
+	public static DateTimeToBinarySerializer Default { get; } = new();
 
 	private readonly IPrimitiveSerializer<long> _innerSerializer;
 
-	/// <summary>Create a <see cref="DateTimeUnixSerializer"/> with the default
+	/// <summary>Create a <see cref="DateTimeToBinarySerializer"/> with the default
 	/// <see cref="Int64LittleEndianSerializer"/> to serialize the ToBinary encoding of the DateTime.</summary>
-	public DateTimeUnixSerializer() : this(Int64LittleEndianSerializer.Default) { }
+	public DateTimeToBinarySerializer() : this(Int64LittleEndianSerializer.Default) { }
 
-	/// <summary>Create a <see cref="DateTimeUnixSerializer"/> with the given long serializer
+	/// <summary>Create a <see cref="DateTimeToBinarySerializer"/> with the given long serializer
 	/// to serialize the ToBinary encoding of the DateTime.</summary>
-	public DateTimeUnixSerializer(IPrimitiveSerializer<long> longSerializer)
+	public DateTimeToBinarySerializer(IPrimitiveSerializer<long> longSerializer)
 	{
 		_innerSerializer = longSerializer;
 		ByteCount = _innerSerializer.ByteCount;

--- a/tests/PandoTests/Tests/Repositories/TestStateTrees/TestTreeSerializer.cs
+++ b/tests/PandoTests/Tests/Repositories/TestStateTrees/TestTreeSerializer.cs
@@ -116,12 +116,12 @@ internal readonly struct DoubleTreeBSerializer : INodeSerializer<TestTree.B>
 
 	public DoubleTreeBSerializer()
 	{
-		NodeSize = DateTimeUnixSerializer.Default.ByteCount + Int32LittleEndianSerializer.Default.ByteCount;
+		NodeSize = DateTimeToBinarySerializer.Default.ByteCount + Int32LittleEndianSerializer.Default.ByteCount;
 	}
 
 	public ulong Serialize(TestTree.B obj, INodeDataSink dataSink)
 	{
-		var timeSerializer = DateTimeUnixSerializer.Default;
+		var timeSerializer = DateTimeToBinarySerializer.Default;
 		var timeSize = timeSerializer.ByteCount!.Value;
 		var centsSerializer = Int32LittleEndianSerializer.Default;
 		var centsSize = centsSerializer.ByteCount!.Value;
@@ -137,7 +137,7 @@ internal readonly struct DoubleTreeBSerializer : INodeSerializer<TestTree.B>
 
 	public TestTree.B Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource _)
 	{
-		var timeSerializer = DateTimeUnixSerializer.Default;
+		var timeSerializer = DateTimeToBinarySerializer.Default;
 		var centsSerializer = Int32LittleEndianSerializer.Default;
 
 		var date = timeSerializer.Deserialize(ref bytes);

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
@@ -91,8 +91,12 @@ public abstract class BaseSerializerTest<T>
 
 		var deserializationResult = Serializer.Deserialize(ref readBuffer);
 
-		deserializationResult.Should().BeEquivalentTo(expectedValue);
+		AssertDeserializedValuesEquivalent(deserializationResult, expectedValue);
 	}
+
+	/// The method used to compare a deserialized result to the expected value.
+	/// By default, this just uses a BeEquivalentTo assertion, but for more complex types this may be overridden.
+	protected virtual void AssertDeserializedValuesEquivalent(T actualValue, T expectedValue) => actualValue.Should().BeEquivalentTo(expectedValue);
 
 #pragma warning disable xUnit1026 // ignore unused parameter warning; we want to use the same data for multiple tests
 

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/SimpleTestPrimitiveSerializers.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/SimpleTestPrimitiveSerializers.cs
@@ -15,13 +15,35 @@ internal class SimpleLongSerializer : IPrimitiveSerializer<long>
 	public void Serialize(long value, ref Span<byte> buffer)
 	{
 		BinaryPrimitives.WriteInt64BigEndian(buffer, value);
-		buffer = buffer[sizeof(ulong)..];
+		buffer = buffer[sizeof(long)..];
 	}
 
 	public long Deserialize(ref ReadOnlySpan<byte> buffer)
 	{
 		var result = BinaryPrimitives.ReadInt64BigEndian(buffer);
-		buffer = buffer[sizeof(ulong)..];
+		buffer = buffer[sizeof(long)..];
+		return result;
+	}
+}
+
+/// A simply implemented int serializer that serializes in big endian encoding
+/// <remarks>This exists to provide a very simple, self-contained serializer that upholds the
+/// IPrimitiveSerializer contract in as few lines as possible for testing.</remarks>
+internal class SimpleIntSerializer : IPrimitiveSerializer<int>
+{
+	public int? ByteCount => sizeof(int);
+	public int ByteCountForValue(int value) => sizeof(int);
+
+	public void Serialize(int value, ref Span<byte> buffer)
+	{
+		BinaryPrimitives.WriteInt32BigEndian(buffer, value);
+		buffer = buffer[sizeof(uint)..];
+	}
+
+	public int Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var result = BinaryPrimitives.ReadInt32BigEndian(buffer);
+		buffer = buffer[sizeof(int)..];
 		return result;
 	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
@@ -1,0 +1,23 @@
+using System;
+using Pando.Serialization.PrimitiveSerializers;
+using Xunit;
+
+// Rider doesn't detect subclasses of BaseSerializerTest as being used, because they inherit their test methods
+// ReSharper disable UnusedType.Global
+
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+public class TimeSerializerTests
+{
+	public class DateTimeUnixSerializerTests : BaseSerializerTest<DateTime>, ISerializerTestData<DateTime>
+	{
+		protected override IPrimitiveSerializer<DateTime> Serializer => new DateTimeUnixSerializer(new SimpleLongSerializer());
+
+		public static TheoryData<DateTime, byte[]> SerializationTestData => new()
+		{
+			{ new DateTime(1415, 10, 25, 12, 34, 56, 789, DateTimeKind.Utc), new byte[] { 0x46, 0x32, 0x2F, 0x8B, 0x6E, 0xBC, 0x3C, 0x50 } }
+		};
+
+		public static TheoryData<int?> ByteCountTestData => new() { sizeof(long) };
+	}
+}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
@@ -53,4 +53,16 @@ public class TimeSerializerTests
 
 		public static TheoryData<int?> ByteCountTestData => new() { sizeof(int) };
 	}
+
+	public class TimeOnlyDayNumberSerializerTests : BaseSerializerTest<TimeOnly>, ISerializerTestData<TimeOnly>
+	{
+		protected override IPrimitiveSerializer<TimeOnly> Serializer => new TimeOnlyTicksSerializer(new SimpleLongSerializer());
+
+		public static TheoryData<TimeOnly, byte[]> SerializationTestData => new()
+		{
+			{ TimeOnly.MaxValue, new byte[] { 0x00, 0x00, 0x00, 0xC9, 0x2A, 0x69, 0xBF, 0xFF } }
+		};
+
+		public static TheoryData<int?> ByteCountTestData => new() { sizeof(long) };
+	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
@@ -29,4 +29,16 @@ public class TimeSerializerTests
 			actualValue.Kind.Should().Be(expectedValue.Kind);
 		}
 	}
+
+	public class TimeSpanTicksSerializerTests : BaseSerializerTest<TimeSpan>, ISerializerTestData<TimeSpan>
+	{
+		protected override IPrimitiveSerializer<TimeSpan> Serializer => new TimeSpanTicksSerializer(new SimpleLongSerializer());
+
+		public static TheoryData<TimeSpan, byte[]> SerializationTestData => new()
+		{
+			{ new TimeSpan(1234567, 89, 87, 65, 4321), new byte[] { 0x0E, 0xCD, 0x91, 0xEF, 0x92, 0x3A, 0xBD, 0x90 } }
+		};
+
+		public static TheoryData<int?> ByteCountTestData => new() { sizeof(long) };
+	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
@@ -10,9 +10,9 @@ namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
 
 public class TimeSerializerTests
 {
-	public class DateTimeUnixSerializerTests : BaseSerializerTest<DateTime>, ISerializerTestData<DateTime>
+	public class DateTimeToBinarySerializerTests : BaseSerializerTest<DateTime>, ISerializerTestData<DateTime>
 	{
-		protected override IPrimitiveSerializer<DateTime> Serializer => new DateTimeUnixSerializer(new SimpleLongSerializer());
+		protected override IPrimitiveSerializer<DateTime> Serializer => new DateTimeToBinarySerializer(new SimpleLongSerializer());
 
 		public static TheoryData<DateTime, byte[]> SerializationTestData => new()
 		{

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using FluentAssertions;
 using Pando.Serialization.PrimitiveSerializers;
 using Xunit;
 
@@ -19,5 +20,13 @@ public class TimeSerializerTests
 		};
 
 		public static TheoryData<int?> ByteCountTestData => new() { sizeof(long) };
+
+		/// By default, date time comparison doesn't compare the Kind property,
+		/// but we want to make sure that the Kind property is serialized/deserialized properly so we manually check it
+		protected override void AssertDeserializedValuesEquivalent(DateTime actualValue, DateTime expectedValue)
+		{
+			base.AssertDeserializedValuesEquivalent(actualValue, expectedValue);
+			actualValue.Kind.Should().Be(expectedValue.Kind);
+		}
 	}
 }

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/TimeSerializerTests.cs
@@ -41,4 +41,16 @@ public class TimeSerializerTests
 
 		public static TheoryData<int?> ByteCountTestData => new() { sizeof(long) };
 	}
+
+	public class DateOnlyDayNumberSerializerTests : BaseSerializerTest<DateOnly>, ISerializerTestData<DateOnly>
+	{
+		protected override IPrimitiveSerializer<DateOnly> Serializer => new DateOnlyDayNumberSerializer(new SimpleIntSerializer());
+
+		public static TheoryData<DateOnly, byte[]> SerializationTestData => new()
+		{
+			{ DateOnly.MaxValue, new byte[] { 0x00, 0x37, 0xB9, 0xDA } }
+		};
+
+		public static TheoryData<int?> ByteCountTestData => new() { sizeof(int) };
+	}
 }


### PR DESCRIPTION
Tests for `DateTimeToBinarySerializer`, `TimeSpanTicksSerializer`, `DateOnlyDayNumberSerializer`, and `TimeOnlyTicksSerializer`

Also rename `DateTimeUnixSerializer` to `DateTimeToBinarySerializer`. It was previously named improperly due to a misunderstanding of the `ToBinary` method