### PR TITLE
PANDO-38: Add FixedSizeBaseSerializer

### DIFF
--- a/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
@@ -1,37 +1,14 @@
 using System;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>bool</c> values as a single byte
-public class BooleanSerializer : IPrimitiveSerializer<bool>
+public class BooleanSerializer : FixedSizeBaseSerializer<bool>
 {
 	/// <summary>A global default instance for <see cref="BooleanSerializer"/></summary>
 	public static BooleanSerializer Default { get; } = new();
 
-	private const int SIZE = 1;
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(bool value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(bool value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		slice[0] = (byte)(value ? 1 : 0);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public bool Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return slice[0] != 0;
-	}
+	protected override int FixedSize => sizeof(byte);
+	protected override void SerializeInner(bool value, Span<byte> slice) => slice[0] = (byte)(value ? 1 : 0);
+	protected override bool DeserializeInner(ReadOnlySpan<byte> slice) => slice[0] != 0;
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
@@ -1,37 +1,14 @@
 using System;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes single <c>byte</c> values
-public class ByteSerializer : IPrimitiveSerializer<byte>
+public class ByteSerializer : FixedSizeBaseSerializer<byte>
 {
 	/// <summary>A global default instance for <see cref="ByteSerializer"/></summary>
 	public static ByteSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(byte);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(byte value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(byte value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		slice[0] = value;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public byte Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return slice[0];
-	}
+	protected override int FixedSize => sizeof(byte);
+	protected override void SerializeInner(byte value, Span<byte> slice) => slice[0] = value;
+	protected override byte DeserializeInner(ReadOnlySpan<byte> slice) => slice[0];
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/FixedSizeBaseSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/FixedSizeBaseSerializer.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+public abstract class FixedSizeBaseSerializer<T> : IPrimitiveSerializer<T>
+{
+	protected abstract int FixedSize
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get;
+	}
+
+	public int? ByteCount
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => FixedSize;
+	}
+
+	public int ByteCountForValue(T value) => FixedSize;
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Serialize(T value, ref Span<byte> buffer)
+	{
+		var slice = buffer[..FixedSize];
+		buffer = buffer[FixedSize..];
+		SerializeInner(value, slice);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public T Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var slice = buffer[..FixedSize];
+		buffer = buffer[FixedSize..];
+		return DeserializeInner(slice);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	protected abstract void SerializeInner(T value, Span<byte> slice);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	protected abstract T DeserializeInner(ReadOnlySpan<byte> slice);
+}

--- a/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
@@ -1,38 +1,15 @@
 using System;
 using System.Buffers.Binary;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>short</c> values in little endian encoding (least significant byte first)
-public class Int16LittleEndianSerializer : IPrimitiveSerializer<short>
+public class Int16LittleEndianSerializer : FixedSizeBaseSerializer<short>
 {
 	/// <summary>A global default instance for <see cref="Int16LittleEndianSerializer"/></summary>
 	public static Int16LittleEndianSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(short);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(short value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(short value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		BinaryPrimitives.WriteInt16LittleEndian(slice, value);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public short Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return BinaryPrimitives.ReadInt16LittleEndian(slice);
-	}
+	protected override int FixedSize => sizeof(short);
+	protected override void SerializeInner(short value, Span<byte> slice) => BinaryPrimitives.WriteInt16LittleEndian(slice, value);
+	protected override short DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadInt16LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
@@ -1,38 +1,15 @@
 using System;
 using System.Buffers.Binary;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>int</c> values in little endian encoding (least significant byte first)
-public class Int32LittleEndianSerializer : IPrimitiveSerializer<int>
+public class Int32LittleEndianSerializer : FixedSizeBaseSerializer<int>
 {
 	/// <summary>A global default instance for <see cref="Int32LittleEndianSerializer"/></summary>
 	public static Int32LittleEndianSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(int);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(int value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(int value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		BinaryPrimitives.WriteInt32LittleEndian(slice, value);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return BinaryPrimitives.ReadInt32LittleEndian(slice);
-	}
+	protected override int FixedSize => sizeof(int);
+	protected override void SerializeInner(int value, Span<byte> slice) => BinaryPrimitives.WriteInt32LittleEndian(slice, value);
+	protected override int DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadInt32LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
@@ -1,38 +1,15 @@
 using System;
 using System.Buffers.Binary;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>long</c> values in little endian encoding (least significant byte first)
-public class Int64LittleEndianSerializer : IPrimitiveSerializer<long>
+public class Int64LittleEndianSerializer : FixedSizeBaseSerializer<long>
 {
 	/// <summary>A global default instance for <see cref="Int64LittleEndianSerializer"/></summary>
 	public static Int64LittleEndianSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(long);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(long value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(long value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		BinaryPrimitives.WriteInt64LittleEndian(slice, value);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public long Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return BinaryPrimitives.ReadInt64LittleEndian(slice);
-	}
+	protected override int FixedSize => sizeof(long);
+	protected override void SerializeInner(long value, Span<byte> slice) => BinaryPrimitives.WriteInt64LittleEndian(slice, value);
+	protected override long DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadInt64LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
@@ -1,37 +1,14 @@
 using System;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>sbyte</c> values
-public class SByteSerializer : IPrimitiveSerializer<sbyte>
+public class SByteSerializer : FixedSizeBaseSerializer<sbyte>
 {
 	/// <summary>A global default instance for <see cref="SByteSerializer"/></summary>
 	public static SByteSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(sbyte);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(sbyte value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(sbyte value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		slice[0] = (byte)value;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public sbyte Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return (sbyte)slice[0];
-	}
+	protected override int FixedSize => sizeof(sbyte);
+	protected override void SerializeInner(sbyte value, Span<byte> slice) => slice[0] = (byte)value;
+	protected override sbyte DeserializeInner(ReadOnlySpan<byte> slice) => (sbyte)slice[0];
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
@@ -1,38 +1,15 @@
 using System;
 using System.Buffers.Binary;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>ushort</c> values in little endian encoding (least significant byte first)
-public class UInt16LittleEndianSerializer : IPrimitiveSerializer<ushort>
+public class UInt16LittleEndianSerializer : FixedSizeBaseSerializer<ushort>
 {
 	/// <summary>A global default instance for <see cref="UInt16LittleEndianSerializer"/></summary>
 	public static UInt16LittleEndianSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(ushort);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(ushort value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(ushort value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		BinaryPrimitives.WriteUInt16LittleEndian(slice, value);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public ushort Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return BinaryPrimitives.ReadUInt16LittleEndian(slice);
-	}
+	protected override int FixedSize => sizeof(ushort);
+	protected override void SerializeInner(ushort value, Span<byte> slice) => BinaryPrimitives.WriteUInt16LittleEndian(slice, value);
+	protected override ushort DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadUInt16LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
@@ -1,38 +1,15 @@
 using System;
 using System.Buffers.Binary;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>uint</c> values in little endian encoding (least significant byte first)
-public class UInt32LittleEndianSerializer : IPrimitiveSerializer<uint>
+public class UInt32LittleEndianSerializer : FixedSizeBaseSerializer<uint>
 {
 	/// <summary>A global default instance for <see cref="UInt32LittleEndianSerializer"/></summary>
 	public static UInt32LittleEndianSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(uint);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(uint value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(uint value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		BinaryPrimitives.WriteUInt32LittleEndian(slice, value);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public uint Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return BinaryPrimitives.ReadUInt32LittleEndian(slice);
-	}
+	protected override int FixedSize => sizeof(uint);
+	protected override void SerializeInner(uint value, Span<byte> slice) => BinaryPrimitives.WriteUInt32LittleEndian(slice, value);
+	protected override uint DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadUInt32LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
@@ -1,38 +1,15 @@
 using System;
 using System.Buffers.Binary;
-using System.Runtime.CompilerServices;
-using Pando.Serialization.Utils;
 
 namespace Pando.Serialization.PrimitiveSerializers;
 
 /// Serializes/deserializes <c>ulong</c> values in little endian encoding (least significant byte first)
-public class UInt64LittleEndianSerializer : IPrimitiveSerializer<ulong>
+public class UInt64LittleEndianSerializer : FixedSizeBaseSerializer<ulong>
 {
 	/// <summary>A global default instance for <see cref="UInt64LittleEndianSerializer"/></summary>
 	public static UInt64LittleEndianSerializer Default { get; } = new();
 
-	private const int SIZE = sizeof(ulong);
-
-	public int? ByteCount
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => SIZE;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public int ByteCountForValue(ulong value) => SIZE;
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Serialize(ulong value, ref Span<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		BinaryPrimitives.WriteUInt64LittleEndian(slice, value);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public ulong Deserialize(ref ReadOnlySpan<byte> buffer)
-	{
-		var slice = SpanHelpers.PopStart(ref buffer, SIZE);
-		return BinaryPrimitives.ReadUInt64LittleEndian(slice);
-	}
+	protected override int FixedSize => sizeof(ulong);
+	protected override void SerializeInner(ulong value, Span<byte> slice) => BinaryPrimitives.WriteUInt64LittleEndian(slice, value);
+	protected override ulong DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadUInt64LittleEndian(slice);
 }


### PR DESCRIPTION
Also convert the integral numeric types to use it. This greatly simplifies and reduces the line count of these classes.