### PR TITLE
PANDO-35: Add StringSerializer and tests

### DIFF
--- a/src/Pando/Serialization/PrimitiveSerializers/StringSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/StringSerializer.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Pando.Serialization.PrimitiveSerializers;
+
+/// Serializes a string encoded as ASCII
+public class StringSerializer : IPrimitiveSerializer<string>
+{
+	private readonly IPrimitiveSerializer<int> _lengthSerializer;
+	private readonly Encoding _encoding;
+
+	public int? ByteCount => null;
+
+	public int ByteCountForValue(string value)
+	{
+		var stringBytes = _encoding.GetByteCount(value);
+		return stringBytes + ByteCountForLength(stringBytes);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private int ByteCountForLength(int stringBytes) => _lengthSerializer.ByteCount ?? _lengthSerializer.ByteCountForValue(stringBytes);
+
+	public StringSerializer(Encoding encoding) : this(Int32LittleEndianSerializer.Default, encoding) { }
+
+	public StringSerializer(IPrimitiveSerializer<int> lengthSerializer, Encoding encoding)
+	{
+		_lengthSerializer = lengthSerializer;
+		_encoding = encoding;
+	}
+
+	public void Serialize(string value, ref Span<byte> buffer)
+	{
+		var stringByteCount = _encoding.GetByteCount(value);
+		var totalByteCount = ByteCountForLength(stringByteCount) + stringByteCount;
+
+		if (buffer.Length < totalByteCount)
+		{
+			throw new ArgumentOutOfRangeException(nameof(buffer),
+				"Buffer is not large enough to encode the given string." +
+				$" Requires {totalByteCount} bytes, but buffer was only {buffer.Length} bytes in length."
+			);
+		}
+
+		_lengthSerializer.Serialize(stringByteCount, ref buffer);
+		_encoding.GetBytes(value, buffer);
+		buffer = buffer[stringByteCount..];
+	}
+
+	public string Deserialize(ref ReadOnlySpan<byte> buffer)
+	{
+		var remainingBuffer = buffer;
+		var stringByteCount = _lengthSerializer.Deserialize(ref remainingBuffer);
+
+		if (remainingBuffer.Length < stringByteCount)
+		{
+			throw new ArgumentOutOfRangeException(nameof(buffer),
+				$"Buffer is not large enough to decode a string with byte length {stringByteCount}." +
+				$"Given buffer is {remainingBuffer.Length} bytes without including length bytes."
+			);
+		}
+
+		var value = _encoding.GetString(remainingBuffer);
+		buffer = remainingBuffer[stringByteCount..];
+
+		return value;
+	}
+}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/StringSerializerTests.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/StringSerializerTests.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using Pando.Serialization.PrimitiveSerializers;
+using Xunit;
+
+// Rider doesn't detect subclasses of BaseSerializerTest as being used, because they inherit their test methods
+// ReSharper disable UnusedType.Global
+
+namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
+
+public partial class PrimitiveSerializerTests
+{
+	public class AsciiStringSerializerTests : BaseSerializerTest<string>, ISerializerTestData<string>
+	{
+		protected override IPrimitiveSerializer<string> Serializer => new StringSerializer(new SimpleIntSerializer(), Encoding.ASCII);
+
+		public static TheoryData<string, byte[]> SerializationTestData => new()
+		{
+			{
+				"Hello World", new byte[]
+				{
+					0x00, 0x00, 0x00, 0x0B,       // Length
+					0x48, 0x65, 0x6C, 0x6C, 0x6F, // "Hello"
+					0x20,                         // " "
+					0x57, 0x6F, 0x72, 0x6C, 0x64  // "World
+				}
+			},
+			{ "", new byte[] { 0x00, 0x00, 0x00, 0x00 } }
+		};
+
+		public static TheoryData<int?> ByteCountTestData => new() { null };
+	}
+
+	public class Utf8StringSerializerTests : BaseSerializerTest<string>, ISerializerTestData<string>
+	{
+		protected override IPrimitiveSerializer<string> Serializer => new StringSerializer(new SimpleIntSerializer(), Encoding.UTF8);
+
+		public static TheoryData<string, byte[]> SerializationTestData => new()
+		{
+			{
+				"👋 Hello World 👋", new byte[]
+				{
+					0x00, 0x00, 0x00, 0x15,       // length
+					0xF0, 0x9F, 0x91, 0x8B,       // "👋"
+					0x20,                         // " "
+					0x48, 0x65, 0x6C, 0x6C, 0x6F, // "Hello"
+					0x20,                         // " "
+					0x57, 0x6F, 0x72, 0x6C, 0x64, // "World
+					0x20,                         // " "
+					0xF0, 0x9F, 0x91, 0x8B,       // "👋"
+				}
+			},
+		};
+
+		public static TheoryData<int?> ByteCountTestData => new() { null };
+	}
+}


### PR DESCRIPTION
- This serializer serializes strings encoded with the length in bytes first, followed by the bytes of the string itself.
- The serializer takes in an int serializer that is used to serialize the length of the string in bytes into the start of the buffer, and an encoding that is used to serialize the string itself into the remainder of the buffer.
- This implementation allows for any string encoding to work generically.