### PR TITLE
PANDO-56: Rework INodeSerializer.Serialize to write to a byte buffer rather than directly submitting to the data sink

### DIFF
--- a/docs/PandoExampleProject/ChessTests.cs
+++ b/docs/PandoExampleProject/ChessTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 using Pando.DataSources;
 using Pando.Repositories;
 using Pando.Serialization;
+using Pando.Serialization.PrimitiveSerializers;
 using PandoExampleProject.Serializers;
 using Xunit;
 
@@ -14,8 +16,8 @@ public class ChessTests
 {
 	private static INodeSerializer<ChessGameState> MakeSerializer() => new ChessStateTreeSerializer(
 		new ChessPlayerStateSerializer(),
-		new WhiteBlackPairTimespanSerializer(),
-		new WhiteBlackPairBranchSerializer<ImmutableArray<ChessPiece>>(
+		new PrimitiveWhiteBlackPairSerializer<TimeSpan>(new TimeSpanTicksSerializer()),
+		new NodeWhiteBlackPairSerializer<ImmutableArray<ChessPiece>>(
 			new ImmutableArraySerializer<ChessPiece>(
 				new ChessPieceSerializer()
 			)

--- a/docs/PandoExampleProject/Serializers/ChessPieceSerializer.cs
+++ b/docs/PandoExampleProject/Serializers/ChessPieceSerializer.cs
@@ -6,30 +6,30 @@ namespace PandoExampleProject.Serializers;
 
 internal class ChessPieceSerializer : INodeSerializer<ChessPiece>
 {
-	private const int SIZE = 5;
+	private const int SIZE = 5 * sizeof(byte);
 	public int? NodeSize => SIZE;
 
-	public ulong Serialize(ChessPiece obj, INodeDataSink dataSink)
+	public int NodeSizeForObject(ChessPiece obj) => SIZE;
+
+	public void Serialize(ChessPiece obj, Span<byte> writeBuffer, INodeDataSink dataSink)
 	{
-		Span<byte> buffer = stackalloc byte[SIZE];
-
-		buffer[0] = (byte)obj.Owner;
-		buffer[1] = (byte)obj.Type;
-		buffer[2] = (byte)obj.CurrentRank;
-		buffer[3] = (byte)obj.CurrentFile;
-		buffer[4] = (byte)obj.State;
-
-		return dataSink.AddNode(buffer);
+		// We *could* use an EnumSerializer for each of these enums, though I think in this case that would be less readable
+		// when writing the serializer manually since the enums can just be directly cast to the underlying type
+		writeBuffer[0] = (byte)obj.Owner;
+		writeBuffer[1] = (byte)obj.Type;
+		writeBuffer[2] = (byte)obj.CurrentRank;
+		writeBuffer[3] = (byte)obj.CurrentFile;
+		writeBuffer[4] = (byte)obj.State;
 	}
 
-	public ChessPiece Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource dataSource)
+	public ChessPiece Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource dataSource)
 	{
 		return new ChessPiece(
-			(Player)bytes[0],
-			(PieceType)bytes[1],
-			(Rank)bytes[2],
-			(File)bytes[3],
-			(ChessPieceState)bytes[4]
+			(Player)readBuffer[0],
+			(PieceType)readBuffer[1],
+			(Rank)readBuffer[2],
+			(File)readBuffer[3],
+			(ChessPieceState)readBuffer[4]
 		);
 	}
 }

--- a/docs/PandoExampleProject/Serializers/ChessPlayerStateSerializer.cs
+++ b/docs/PandoExampleProject/Serializers/ChessPlayerStateSerializer.cs
@@ -6,21 +6,19 @@ namespace PandoExampleProject.Serializers;
 
 internal class ChessPlayerStateSerializer : INodeSerializer<ChessPlayerState>
 {
-	private const int SIZE = 2;
+	private const int SIZE = 2 * sizeof(byte);
 	public int? NodeSize => SIZE;
 
-	public ulong Serialize(ChessPlayerState obj, INodeDataSink dataSink)
+	public int NodeSizeForObject(ChessPlayerState obj) => SIZE;
+
+	public void Serialize(ChessPlayerState obj, Span<byte> writeBuffer, INodeDataSink dataSink)
 	{
-		Span<byte> buffer = stackalloc byte[SIZE];
-
-		buffer[0] = (byte)obj.CurrentTurn;
-		buffer[1] = (byte)obj.Winner;
-
-		return dataSink.AddNode(buffer);
+		writeBuffer[0] = (byte)obj.CurrentTurn;
+		writeBuffer[1] = (byte)obj.Winner;
 	}
 
-	public ChessPlayerState Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource dataSource)
+	public ChessPlayerState Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource dataSource)
 	{
-		return new ChessPlayerState((Player)bytes[0], (Winner)bytes[1]);
+		return new ChessPlayerState((Player)readBuffer[0], (Winner)readBuffer[1]);
 	}
 }

--- a/docs/PandoExampleProject/Serializers/ChessStateTreeSerializer.cs
+++ b/docs/PandoExampleProject/Serializers/ChessStateTreeSerializer.cs
@@ -17,7 +17,6 @@ internal class ChessStateTreeSerializer : INodeSerializer<ChessGameState>
 	private readonly INodeSerializer<WhiteBlackPair<TimeSpan>> _remainingTimeSerializer;
 	private readonly INodeSerializer<WhiteBlackPair<ImmutableArray<ChessPiece>>> _playerPiecesSerializer;
 
-	public int? NodeSize { get; }
 
 	public ChessStateTreeSerializer(
 		INodeSerializer<ChessPlayerState> playerStateSerializer,
@@ -31,35 +30,42 @@ internal class ChessStateTreeSerializer : INodeSerializer<ChessGameState>
 		NodeSize = _playerStateSerializer.NodeSize + _remainingTimeSerializer.NodeSize + _playerPiecesSerializer.NodeSize;
 	}
 
+	public int? NodeSize { get; }
+
+	public int NodeSizeForObject(ChessGameState obj)
+		=> NodeSize
+			?? _playerStateSerializer.NodeSizeForObject(obj.PlayerState)
+			+ _remainingTimeSerializer.NodeSizeForObject(obj.RemainingTime)
+			+ _playerPiecesSerializer.NodeSizeForObject(obj.PlayerPieces);
+
 	/// <param name="obj">ChessGameState that we want to serialize to the data sink</param>
+	/// <param name="writeBuffer">The buffer into which to write the binary representation of the given <paramref name="obj"/></param>
 	/// <param name="dataSink">Data sink we want to serialize to</param>
-	public ulong Serialize(ChessGameState obj, INodeDataSink dataSink)
+	public void Serialize(ChessGameState obj, Span<byte> writeBuffer, INodeDataSink dataSink)
 	{
+		var (chessPlayerState, whiteBlackPair, playerPieces) = obj;
+
 		// Get the hash of each child node by serializing them to the data sink
-		ulong playerStateHash = _playerStateSerializer.Serialize(obj.PlayerState, dataSink);
-		ulong remainingTimeHash = _remainingTimeSerializer.Serialize(obj.RemainingTime, dataSink);
-		ulong piecesHash = _playerPiecesSerializer.Serialize(obj.PlayerPieces, dataSink);
+		ulong playerStateHash = _playerStateSerializer.SerializeToHash(chessPlayerState, dataSink);
+		ulong remainingTimeHash = _remainingTimeSerializer.SerializeToHash(whiteBlackPair, dataSink);
+		ulong piecesHash = _playerPiecesSerializer.SerializeToHash(playerPieces, dataSink);
 
-		// Write each hash to a buffer
+		// Write each hash to the given write buffer
 		// *Pando always assumes little endian*
-		Span<byte> buffer = stackalloc byte[sizeof(ulong) * 3];
-		BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(0, sizeof(ulong)), playerStateHash);
-		BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(sizeof(ulong), sizeof(ulong)), remainingTimeHash);
-		BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(sizeof(ulong) * 2, sizeof(ulong)), piecesHash);
-
-		// Write the branch data to the data sink, returning the resulting hash of this node
-		return dataSink.AddNode(buffer);
+		BinaryPrimitives.WriteUInt64LittleEndian(writeBuffer.Slice(0, sizeof(ulong)), playerStateHash);
+		BinaryPrimitives.WriteUInt64LittleEndian(writeBuffer.Slice(sizeof(ulong), sizeof(ulong)), remainingTimeHash);
+		BinaryPrimitives.WriteUInt64LittleEndian(writeBuffer.Slice(sizeof(ulong) * 2, sizeof(ulong)), piecesHash);
 	}
 
-	/// <param name="bytes">The raw byte data of this branch node</param>
+	/// <param name="readBuffer">The raw byte data of this branch node</param>
 	/// <param name="dataSource">The data source to pull child nodes from</param>
-	public ChessGameState Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource dataSource)
+	public ChessGameState Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource dataSource)
 	{
 		// Get child hashes from raw data
 		// *Pando always assumes little endian*
-		ulong playerStateHash = BinaryPrimitives.ReadUInt64LittleEndian(bytes.Slice(0, sizeof(ulong)));
-		ulong remainingTimeHash = BinaryPrimitives.ReadUInt64LittleEndian(bytes.Slice(sizeof(ulong), sizeof(ulong)));
-		ulong playerPiecesHash = BinaryPrimitives.ReadUInt64LittleEndian(bytes.Slice(sizeof(ulong) * 2, sizeof(ulong)));
+		ulong playerStateHash = BinaryPrimitives.ReadUInt64LittleEndian(readBuffer.Slice(0, sizeof(ulong)));
+		ulong remainingTimeHash = BinaryPrimitives.ReadUInt64LittleEndian(readBuffer.Slice(sizeof(ulong), sizeof(ulong)));
+		ulong playerPiecesHash = BinaryPrimitives.ReadUInt64LittleEndian(readBuffer.Slice(sizeof(ulong) * 2, sizeof(ulong)));
 
 		// Get child nodes from data source
 		var playerState = _playerStateSerializer.DeserializeFromHash(playerStateHash, dataSource);

--- a/docs/PandoExampleProject/Serializers/ImmutableArraySerializer.cs
+++ b/docs/PandoExampleProject/Serializers/ImmutableArraySerializer.cs
@@ -8,8 +8,6 @@ namespace PandoExampleProject.Serializers;
 
 public class ImmutableArraySerializer<TNode> : INodeSerializer<ImmutableArray<TNode>>
 {
-	public int? NodeSize => null;
-
 	private readonly INodeSerializer<TNode> _elementSerializer;
 
 	public ImmutableArraySerializer(INodeSerializer<TNode> elementSerializer)
@@ -17,28 +15,27 @@ public class ImmutableArraySerializer<TNode> : INodeSerializer<ImmutableArray<TN
 		_elementSerializer = elementSerializer;
 	}
 
-	public ulong Serialize(ImmutableArray<TNode> obj, INodeDataSink dataSink)
+	public int? NodeSize => null;
+
+	public int NodeSizeForObject(ImmutableArray<TNode> array) => array.Length * sizeof(ulong);
+
+	public void Serialize(ImmutableArray<TNode> array, Span<byte> writeBuffer, INodeDataSink dataSink)
 	{
-		var len = obj.Length;
-		Span<byte> buffer = stackalloc byte[sizeof(ulong) * len];
-
-		for (int i = 0; i < len; i++)
+		for (int i = 0; i < array.Length; i++)
 		{
-			var hash = _elementSerializer.Serialize(obj[i], dataSink);
-			BinaryPrimitives.WriteUInt64LittleEndian(buffer.Slice(i * sizeof(ulong), sizeof(ulong)), hash);
+			var hash = _elementSerializer.SerializeToHash(array[i], dataSink);
+			BinaryPrimitives.WriteUInt64LittleEndian(writeBuffer.Slice(i * sizeof(ulong), sizeof(ulong)), hash);
 		}
-
-		return dataSink.AddNode(buffer);
 	}
 
-	public ImmutableArray<TNode> Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource dataSource)
+	public ImmutableArray<TNode> Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource dataSource)
 	{
-		var len = bytes.Length / sizeof(ulong);
+		var len = readBuffer.Length / sizeof(ulong);
 		var arrayBuilder = ImmutableArray.CreateBuilder<TNode>(len);
 
 		for (int i = 0; i < len; i++)
 		{
-			var hash = BinaryPrimitives.ReadUInt64LittleEndian(bytes.Slice(sizeof(ulong) * i, sizeof(ulong)));
+			var hash = BinaryPrimitives.ReadUInt64LittleEndian(readBuffer.Slice(sizeof(ulong) * i, sizeof(ulong)));
 			arrayBuilder.Add(_elementSerializer.DeserializeFromHash(hash, dataSource));
 		}
 

--- a/src/Pando/Repositories/PandoRepository.cs
+++ b/src/Pando/Repositories/PandoRepository.cs
@@ -32,7 +32,7 @@ public class PandoRepository<T> : IRepository<T>
 	{
 		if (_dataSource.SnapshotCount > 0) throw new AlreadyHasRootSnapshotException();
 
-		var nodeHash = _serializer.Serialize(tree, _dataSource);
+		var nodeHash = _serializer.SerializeToHash(tree, _dataSource);
 		var snapshotHash = _dataSource.AddSnapshot(0UL, nodeHash);
 		AddToSnapshotTree(snapshotHash);
 		return snapshotHash;
@@ -47,7 +47,7 @@ public class PandoRepository<T> : IRepository<T>
 			);
 		}
 
-		var nodeHash = _serializer.Serialize(tree, _dataSource);
+		var nodeHash = _serializer.SerializeToHash(tree, _dataSource);
 		var snapshotHash = _dataSource.AddSnapshot(parentHash, nodeHash);
 		AddToSnapshotTree(snapshotHash, parentHash);
 		return snapshotHash;

--- a/src/Pando/Serialization/INodeSerializer.cs
+++ b/src/Pando/Serialization/INodeSerializer.cs
@@ -3,20 +3,17 @@ using Pando.DataSources;
 
 namespace Pando.Serialization;
 
-public interface INodeWriter<in T>
-{
-	ulong Serialize(T obj, INodeDataSink dataSink);
-}
-
-public interface INodeReader<out T>
-{
-	T Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource dataSource);
-}
-
-public interface INodeSerializer<T> : INodeWriter<T>, INodeReader<T>
+public interface INodeSerializer<T>
 {
 	/// The size in bytes of the data produced by this serializer, if known.
 	/// If the size can be dynamic, should return null.
 	/// <remarks>This should be constant after initialization. If the size of the data can vary, return null</remarks>
 	int? NodeSize { get; }
+
+	/// Returns the size of the buffer required to serialize the given object.
+	int NodeSizeForObject(T obj);
+
+	void Serialize(T obj, Span<byte> writeBuffer, INodeDataSink dataSink);
+
+	T Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource dataSource);
 }

--- a/src/Pando/Serialization/NodeSerializerExtensions.cs
+++ b/src/Pando/Serialization/NodeSerializerExtensions.cs
@@ -5,6 +5,17 @@ namespace Pando.Serialization;
 
 public static class NodeSerializerExtensions
 {
+	/// Uses this serializer to serialize the given object and write the resulting binary representation to the given data sink.
+	/// <returns>The hash of the serialized object in the data sink.</returns>
+	public static ulong SerializeToHash<T>(this INodeSerializer<T> serializer, T obj, INodeDataSink dataSink)
+	{
+		var nodeSize = serializer.NodeSize ?? serializer.NodeSizeForObject(obj);
+		Span<byte> buffer = stackalloc byte[nodeSize];
+		serializer.Serialize(obj, buffer, dataSink);
+		return dataSink.AddNode(buffer);
+	}
+
+	/// Uses this serializer to deserialize the object identified by the given hash in the given data source.
 	public static T DeserializeFromHash<T>(this INodeSerializer<T> serializer, ulong hash, INodeDataSource dataSource)
 	{
 		var nodeSize = serializer.NodeSize ?? dataSource.GetSizeOfNode(hash);

--- a/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/BooleanSerializer.cs
@@ -8,7 +8,7 @@ public class BooleanSerializer : FixedSizeBaseSerializer<bool>
 	/// <summary>A global default instance for <see cref="BooleanSerializer"/></summary>
 	public static BooleanSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(byte);
+	public override int FixedSize => sizeof(byte);
 	protected override void SerializeInner(bool value, Span<byte> slice) => slice[0] = (byte)(value ? 1 : 0);
 	protected override bool DeserializeInner(ReadOnlySpan<byte> slice) => slice[0] != 0;
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/ByteSerializer.cs
@@ -8,7 +8,7 @@ public class ByteSerializer : FixedSizeBaseSerializer<byte>
 	/// <summary>A global default instance for <see cref="ByteSerializer"/></summary>
 	public static ByteSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(byte);
+	public override int FixedSize => sizeof(byte);
 	protected override void SerializeInner(byte value, Span<byte> slice) => slice[0] = value;
 	protected override byte DeserializeInner(ReadOnlySpan<byte> slice) => slice[0];
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/DoubleLittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/DoubleLittleEndianSerializer.cs
@@ -8,7 +8,7 @@ public class DoubleLittleEndianSerializer : FixedSizeBaseSerializer<double>
 	/// <summary>A global default instance for <see cref="SingleLittleEndianSerializer"/></summary>
 	public static DoubleLittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(double);
+	public override int FixedSize => sizeof(double);
 	protected override void SerializeInner(double value, Span<byte> slice) => BinaryPrimitives.WriteDoubleLittleEndian(slice, value);
 	protected override double DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadDoubleLittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/EnumSerializer.cs
@@ -30,6 +30,7 @@ public sealed class EnumSerializer<TEnum, TUnderlying> : IPrimitiveSerializer<TE
 
 	public unsafe void Serialize(TEnum value, ref Span<byte> buffer)
 	{
+		// pointer magic: get address of value, cast to pointer to underlying type, dereference pointer to underlying type.
 		var underlying = *(TUnderlying*)(&value);
 		_underlyingSerializer.Serialize(underlying, ref buffer);
 	}
@@ -37,6 +38,7 @@ public sealed class EnumSerializer<TEnum, TUnderlying> : IPrimitiveSerializer<TE
 	public unsafe TEnum Deserialize(ref ReadOnlySpan<byte> buffer)
 	{
 		var underlying = _underlyingSerializer.Deserialize(ref buffer);
+		// pointer magic: get address of underlying value, cast to pointer of enum type, dereference pointer to enum type.
 		return *(TEnum*)(&underlying);
 	}
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/FixedSizeBaseSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/FixedSizeBaseSerializer.cs
@@ -5,7 +5,7 @@ namespace Pando.Serialization.PrimitiveSerializers;
 
 public abstract class FixedSizeBaseSerializer<T> : IPrimitiveSerializer<T>
 {
-	protected abstract int FixedSize
+	public abstract int FixedSize
 	{
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		get;

--- a/src/Pando/Serialization/PrimitiveSerializers/HalfLittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/HalfLittleEndianSerializer.cs
@@ -8,7 +8,7 @@ public class HalfLittleEndianSerializer : FixedSizeBaseSerializer<Half>
 	/// <summary>A global default instance for <see cref="SingleLittleEndianSerializer"/></summary>
 	public static HalfLittleEndianSerializer Default { get; } = new();
 
-	protected override unsafe int FixedSize => sizeof(Half);
+	public override unsafe int FixedSize => sizeof(Half);
 	protected override void SerializeInner(Half value, Span<byte> slice) => BinaryPrimitives.WriteHalfLittleEndian(slice, value);
 	protected override Half DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadHalfLittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int16LittleEndianSerializer.cs
@@ -9,7 +9,7 @@ public class Int16LittleEndianSerializer : FixedSizeBaseSerializer<short>
 	/// <summary>A global default instance for <see cref="Int16LittleEndianSerializer"/></summary>
 	public static Int16LittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(short);
+	public override int FixedSize => sizeof(short);
 	protected override void SerializeInner(short value, Span<byte> slice) => BinaryPrimitives.WriteInt16LittleEndian(slice, value);
 	protected override short DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadInt16LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int32LittleEndianSerializer.cs
@@ -9,7 +9,7 @@ public class Int32LittleEndianSerializer : FixedSizeBaseSerializer<int>
 	/// <summary>A global default instance for <see cref="Int32LittleEndianSerializer"/></summary>
 	public static Int32LittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(int);
+	public override int FixedSize => sizeof(int);
 	protected override void SerializeInner(int value, Span<byte> slice) => BinaryPrimitives.WriteInt32LittleEndian(slice, value);
 	protected override int DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadInt32LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/Int64LIttleEndianSerializer.cs
@@ -9,7 +9,7 @@ public class Int64LittleEndianSerializer : FixedSizeBaseSerializer<long>
 	/// <summary>A global default instance for <see cref="Int64LittleEndianSerializer"/></summary>
 	public static Int64LittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(long);
+	public override int FixedSize => sizeof(long);
 	protected override void SerializeInner(long value, Span<byte> slice) => BinaryPrimitives.WriteInt64LittleEndian(slice, value);
 	protected override long DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadInt64LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/SByteSerializer.cs
@@ -8,7 +8,7 @@ public class SByteSerializer : FixedSizeBaseSerializer<sbyte>
 	/// <summary>A global default instance for <see cref="SByteSerializer"/></summary>
 	public static SByteSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(sbyte);
+	public override int FixedSize => sizeof(sbyte);
 	protected override void SerializeInner(sbyte value, Span<byte> slice) => slice[0] = (byte)value;
 	protected override sbyte DeserializeInner(ReadOnlySpan<byte> slice) => (sbyte)slice[0];
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/SingleLittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/SingleLittleEndianSerializer.cs
@@ -8,7 +8,7 @@ public class SingleLittleEndianSerializer : FixedSizeBaseSerializer<float>
 	/// <summary>A global default instance for <see cref="SingleLittleEndianSerializer"/></summary>
 	public static SingleLittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(float);
+	public override int FixedSize => sizeof(float);
 	protected override void SerializeInner(float value, Span<byte> slice) => BinaryPrimitives.WriteSingleLittleEndian(slice, value);
 	protected override float DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadSingleLittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/StringSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/StringSerializer.cs
@@ -60,7 +60,7 @@ public class StringSerializer : IPrimitiveSerializer<string>
 			);
 		}
 
-		var value = _encoding.GetString(remainingBuffer);
+		var value = _encoding.GetString(remainingBuffer[..stringByteCount]);
 		buffer = remainingBuffer[stringByteCount..];
 
 		return value;

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt16LittleEndianSerializer.cs
@@ -9,7 +9,7 @@ public class UInt16LittleEndianSerializer : FixedSizeBaseSerializer<ushort>
 	/// <summary>A global default instance for <see cref="UInt16LittleEndianSerializer"/></summary>
 	public static UInt16LittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(ushort);
+	public override int FixedSize => sizeof(ushort);
 	protected override void SerializeInner(ushort value, Span<byte> slice) => BinaryPrimitives.WriteUInt16LittleEndian(slice, value);
 	protected override ushort DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadUInt16LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt32LittleEndianSerializer.cs
@@ -9,7 +9,7 @@ public class UInt32LittleEndianSerializer : FixedSizeBaseSerializer<uint>
 	/// <summary>A global default instance for <see cref="UInt32LittleEndianSerializer"/></summary>
 	public static UInt32LittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(uint);
+	public override int FixedSize => sizeof(uint);
 	protected override void SerializeInner(uint value, Span<byte> slice) => BinaryPrimitives.WriteUInt32LittleEndian(slice, value);
 	protected override uint DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadUInt32LittleEndian(slice);
 }

--- a/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
+++ b/src/Pando/Serialization/PrimitiveSerializers/UInt64LittleEndianSerializer.cs
@@ -9,7 +9,7 @@ public class UInt64LittleEndianSerializer : FixedSizeBaseSerializer<ulong>
 	/// <summary>A global default instance for <see cref="UInt64LittleEndianSerializer"/></summary>
 	public static UInt64LittleEndianSerializer Default { get; } = new();
 
-	protected override int FixedSize => sizeof(ulong);
+	public override int FixedSize => sizeof(ulong);
 	protected override void SerializeInner(ulong value, Span<byte> slice) => BinaryPrimitives.WriteUInt64LittleEndian(slice, value);
 	protected override ulong DeserializeInner(ReadOnlySpan<byte> slice) => BinaryPrimitives.ReadUInt64LittleEndian(slice);
 }

--- a/tests/PandoTests/Tests/Repositories/PandoRepositoryTests.cs
+++ b/tests/PandoTests/Tests/Repositories/PandoRepositoryTests.cs
@@ -75,7 +75,7 @@ public class PandoRepositoryTests
 			// Arrange
 			var repository = new PandoRepository<TestTree>(
 				new MemoryDataSource(),
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			// Act
@@ -100,7 +100,7 @@ public class PandoRepositoryTests
 			var nodeData = new SpannableList<byte>();
 			var repository = new PandoRepository<TestTree>(
 				new MemoryDataSource(nodeIndex: nodeIndex, nodeData: nodeData),
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			// Act
@@ -108,7 +108,7 @@ public class PandoRepositoryTests
 			repository.SaveSnapshot(tree2, rootHash);
 
 			// Assert
-			nodeIndex.Count.Should().Be(4, "because a TestTree has 4 blobs");
+			nodeIndex.Count.Should().Be(3, "because a TestTree is made of 3 blobs");
 		}
 
 		[Fact]
@@ -121,7 +121,7 @@ public class PandoRepositoryTests
 			// Arrange
 			var repository = new PandoRepository<TestTree>(
 				new MemoryDataSource(),
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 			repository.SaveRootSnapshot(tree);
 
@@ -144,7 +144,7 @@ public class PandoRepositoryTests
 			// Arrange
 			var repository = new PandoRepository<TestTree>(
 				new MemoryDataSource(),
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			// Act
@@ -163,7 +163,7 @@ public class PandoRepositoryTests
 			var source = new MemoryDataSource();
 			var repository = new PandoRepository<TestTree>(
 				source,
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			repository.Invoking(repo => repo.SaveSnapshot(tree1, 0UL))
@@ -188,7 +188,7 @@ public class PandoRepositoryTests
 			// Arrange
 			var repository = new PandoRepository<TestTree>(
 				new MemoryDataSource(),
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 			var rootHash = repository.SaveRootSnapshot(tree1);
 			var child1Hash = repository.SaveSnapshot(tree2, rootHash);
@@ -222,7 +222,7 @@ public class PandoRepositoryTests
 
 			var repository = new PandoRepository<TestTree>(
 				source,
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			// Act
@@ -252,7 +252,7 @@ public class PandoRepositoryTests
 
 			var repository = new PandoRepository<TestTree>(
 				source,
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			// Act
@@ -286,7 +286,7 @@ public class PandoRepositoryTests
 		{
 			var repository = new PandoRepository<TestTree>(
 				new MemoryDataSource(),
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			repository.Invoking(repo => repo.GetSnapshotTree()).Should().Throw<NoRootSnapshotException>();
@@ -307,7 +307,7 @@ public class PandoRepositoryTests
 					new MemoryDataSource(),
 					new StreamDataSource(snapshotIndex, leafSnapshots, nodeIndex, nodeData)
 				),
-				TestTreeSerializer.Create()
+				new TestTreeSerializer()
 			);
 
 			var rootHash = repository.SaveRootSnapshot(MakeTestTree1());

--- a/tests/PandoTests/Tests/Repositories/TestStateTrees/TestTreeSerializer.cs
+++ b/tests/PandoTests/Tests/Repositories/TestStateTrees/TestTreeSerializer.cs
@@ -45,7 +45,7 @@ internal readonly struct DoubleTreeASerializer : INodeSerializer<TestTree.A>
 
 	public DoubleTreeASerializer()
 	{
-		_size = Int32LittleEndianSerializer.Default.ByteCount!.Value;
+		_size = Int32LittleEndianSerializer.Default.FixedSize;
 	}
 
 	public int? NodeSize => _size;
@@ -73,7 +73,7 @@ internal readonly struct DoubleTreeBSerializer : INodeSerializer<TestTree.B>
 	public int? NodeSize { get; }
 
 	public int NodeSizeForObject(TestTree.B obj)
-		=> NodeSize ?? DateTimeToBinarySerializer.Default.ByteCountForValue(obj.Time) + Int32LittleEndianSerializer.Default.ByteCount!.Value;
+		=> NodeSize ?? DateTimeToBinarySerializer.Default.ByteCountForValue(obj.Time) + Int32LittleEndianSerializer.Default.FixedSize;
 
 	public void Serialize(TestTree.B obj, Span<byte> writeBuffer, INodeDataSink _)
 	{

--- a/tests/PandoTests/Tests/Repositories/TestStateTrees/TestTreeSerializer.cs
+++ b/tests/PandoTests/Tests/Repositories/TestStateTrees/TestTreeSerializer.cs
@@ -4,62 +4,34 @@ using Pando.DataSources;
 using Pando.DataSources.Utils;
 using Pando.Serialization;
 using Pando.Serialization.PrimitiveSerializers;
-using Pando.Serialization.Utils;
 
 namespace PandoTests.Tests.Repositories.TestStateTrees;
 
 internal readonly struct TestTreeSerializer : INodeSerializer<TestTree>
 {
-	private readonly INodeSerializer<string> _nameSerializer;
-	private readonly INodeSerializer<TestTree.A> _aSerializer;
-	private readonly INodeSerializer<TestTree.B> _bSerializer;
+	private readonly IPrimitiveSerializer<string> _nameSerializer = new StringSerializer(Encoding.UTF8);
+	private readonly INodeSerializer<TestTree.A> _aSerializer = new DoubleTreeASerializer();
+	private readonly INodeSerializer<TestTree.B> _bSerializer = new DoubleTreeBSerializer();
 
-	public int? NodeSize { get; }
+	public int? NodeSize => null;
+	public int NodeSizeForObject(TestTree obj) => 2 * sizeof(ulong) + _nameSerializer.ByteCountForValue(obj.Name);
 
-	public TestTreeSerializer(
-		INodeSerializer<string> nameSerializer,
-		INodeSerializer<TestTree.A> aSerializer,
-		INodeSerializer<TestTree.B> bSerializer
-	)
+	public void Serialize(TestTree obj, Span<byte> writeBuffer, INodeDataSink dataSink)
 	{
-		_nameSerializer = nameSerializer;
-		_aSerializer = aSerializer;
-		_bSerializer = bSerializer;
-		NodeSize = _nameSerializer.NodeSize + _aSerializer.NodeSize + _bSerializer.NodeSize;
+		var myAHash = _aSerializer.SerializeToHash(obj.MyA, dataSink);
+		var myBHash = _bSerializer.SerializeToHash(obj.MyB, dataSink);
+
+		_nameSerializer.Serialize(obj.Name, ref writeBuffer);
+		ByteEncoder.CopyBytes(myAHash, writeBuffer.Slice(0, sizeof(ulong)));
+		ByteEncoder.CopyBytes(myBHash, writeBuffer.Slice(sizeof(ulong), sizeof(ulong)));
 	}
 
-	/// Creates a new TestTreeSerializerDeserializer with the default configuration injected.
-	/// This is only used for convenience while testing.
-	public static TestTreeSerializer Create() => new(
-		new StringSerializer(),
-		new DoubleTreeASerializer(),
-		new DoubleTreeBSerializer()
-	);
-
-	private const int SIZE_OF_HASH = sizeof(ulong);
-	private const int SIZE = SIZE_OF_HASH * 3;
-
-	public ulong Serialize(TestTree obj, INodeDataSink dataSink)
+	public TestTree Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource dataSource)
 	{
-		var nameHash = _nameSerializer.Serialize(obj.Name, dataSink);
-		var myAHash = _aSerializer.Serialize(obj.MyA, dataSink);
-		var myBHash = _bSerializer.Serialize(obj.MyB, dataSink);
+		var name = _nameSerializer.Deserialize(ref readBuffer);
+		var myAHash = ByteEncoder.GetUInt64(readBuffer.Slice(0, sizeof(ulong)));
+		var myBHash = ByteEncoder.GetUInt64(readBuffer.Slice(sizeof(ulong), sizeof(ulong)));
 
-		Span<byte> nodeBytes = stackalloc byte[SIZE];
-		var writeBuffer = nodeBytes;
-		ByteEncoder.CopyBytes(nameHash, SpanHelpers.PopStart(ref writeBuffer, SIZE_OF_HASH));
-		ByteEncoder.CopyBytes(myAHash, SpanHelpers.PopStart(ref writeBuffer, SIZE_OF_HASH));
-		ByteEncoder.CopyBytes(myBHash, SpanHelpers.PopStart(ref writeBuffer, SIZE_OF_HASH));
-		return dataSink.AddNode(nodeBytes);
-	}
-
-	public TestTree Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource dataSource)
-	{
-		var nameHash = ByteEncoder.GetUInt64(SpanHelpers.PopStart(ref bytes, SIZE_OF_HASH));
-		var myAHash = ByteEncoder.GetUInt64(SpanHelpers.PopStart(ref bytes, SIZE_OF_HASH));
-		var myBHash = ByteEncoder.GetUInt64(SpanHelpers.PopStart(ref bytes, SIZE_OF_HASH));
-
-		var name = _nameSerializer.DeserializeFromHash(nameHash, dataSource);
 		var myA = _aSerializer.DeserializeFromHash(myAHash, dataSource);
 		var myB = _bSerializer.DeserializeFromHash(myBHash, dataSource);
 
@@ -67,81 +39,52 @@ internal readonly struct TestTreeSerializer : INodeSerializer<TestTree>
 	}
 }
 
-internal readonly struct StringSerializer : INodeSerializer<string>
-{
-	public int? NodeSize => null;
-
-	public ulong Serialize(string str, INodeDataSink dataSink)
-	{
-		var nameByteCount = Encoding.UTF8.GetByteCount(str);
-		Span<byte> buffer = stackalloc byte[nameByteCount];
-		Encoding.UTF8.GetBytes(str, buffer);
-		return dataSink.AddNode(buffer);
-	}
-
-	public string Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource _)
-	{
-		return Encoding.UTF8.GetString(bytes);
-	}
-}
-
 internal readonly struct DoubleTreeASerializer : INodeSerializer<TestTree.A>
 {
-	public int? NodeSize { get; }
+	private readonly int _size;
 
 	public DoubleTreeASerializer()
 	{
-		NodeSize = Int32LittleEndianSerializer.Default.ByteCount;
+		_size = Int32LittleEndianSerializer.Default.ByteCount!.Value;
 	}
 
-	public ulong Serialize(TestTree.A obj, INodeDataSink dataSink)
+	public int? NodeSize => _size;
+	public int NodeSizeForObject(TestTree.A obj) => _size;
+
+	public void Serialize(TestTree.A obj, Span<byte> buffer, INodeDataSink _)
 	{
-		Span<byte>
-			nodeBytes = stackalloc byte[NodeSize!.Value]; // Since we're using a concrete primitive serializer we can know that NodeSize is safe
-		var writeBuffer = nodeBytes;
-		Int32LittleEndianSerializer.Default.Serialize(obj.Age, ref writeBuffer);
-		return dataSink.AddNode(nodeBytes);
+		Int32LittleEndianSerializer.Default.Serialize(obj.Age, ref buffer);
 	}
 
-	public TestTree.A Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource _)
+	public TestTree.A Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource _)
 	{
-		var age = Int32LittleEndianSerializer.Default.Deserialize(ref bytes);
+		var age = Int32LittleEndianSerializer.Default.Deserialize(ref readBuffer);
 		return new TestTree.A(age);
 	}
 }
 
 internal readonly struct DoubleTreeBSerializer : INodeSerializer<TestTree.B>
 {
-	public int? NodeSize { get; }
-
 	public DoubleTreeBSerializer()
 	{
 		NodeSize = DateTimeToBinarySerializer.Default.ByteCount + Int32LittleEndianSerializer.Default.ByteCount;
 	}
 
-	public ulong Serialize(TestTree.B obj, INodeDataSink dataSink)
+	public int? NodeSize { get; }
+
+	public int NodeSizeForObject(TestTree.B obj)
+		=> NodeSize ?? DateTimeToBinarySerializer.Default.ByteCountForValue(obj.Time) + Int32LittleEndianSerializer.Default.ByteCount!.Value;
+
+	public void Serialize(TestTree.B obj, Span<byte> writeBuffer, INodeDataSink _)
 	{
-		var timeSerializer = DateTimeToBinarySerializer.Default;
-		var timeSize = timeSerializer.ByteCount!.Value;
-		var centsSerializer = Int32LittleEndianSerializer.Default;
-		var centsSize = centsSerializer.ByteCount!.Value;
-
-		Span<byte> buffer = stackalloc byte[timeSize + centsSize];
-		var writeBuffer = buffer;
-
-		timeSerializer.Serialize(obj.Time, ref writeBuffer);
-		centsSerializer.Serialize(obj.Cents, ref writeBuffer);
-
-		return dataSink.AddNode(buffer);
+		DateTimeToBinarySerializer.Default.Serialize(obj.Time, ref writeBuffer);
+		Int32LittleEndianSerializer.Default.Serialize(obj.Cents, ref writeBuffer);
 	}
 
-	public TestTree.B Deserialize(ReadOnlySpan<byte> bytes, INodeDataSource _)
+	public TestTree.B Deserialize(ReadOnlySpan<byte> readBuffer, INodeDataSource _)
 	{
-		var timeSerializer = DateTimeToBinarySerializer.Default;
-		var centsSerializer = Int32LittleEndianSerializer.Default;
-
-		var date = timeSerializer.Deserialize(ref bytes);
-		var cents = centsSerializer.Deserialize(ref bytes);
+		var date = DateTimeToBinarySerializer.Default.Deserialize(ref readBuffer);
+		var cents = Int32LittleEndianSerializer.Default.Deserialize(ref readBuffer);
 
 		return new TestTree.B(date, cents);
 	}

--- a/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
+++ b/tests/PandoTests/Tests/Serialization/PrimitiveSerializers/BaseSerializerTest.cs
@@ -9,7 +9,7 @@ namespace PandoTests.Tests.Serialization.PrimitiveSerializers;
 public abstract class BaseSerializerTest<T>
 {
 	/// Used to overallocate serialization/deserialization buffers so that we can verify that the serializers chop off the appropriate number of bytes.
-	private const int EXTRA_BUFFER_SPACE = 1;
+	private const int EXTRA_BUFFER_SPACE = 4;
 
 	/// Provides the serializer under test
 	protected abstract IPrimitiveSerializer<T> Serializer { get; }
@@ -85,7 +85,9 @@ public abstract class BaseSerializerTest<T>
 	[MemberData(nameof(ISerializerTestData<T>.SerializationTestData))]
 	public virtual void Deserialize_should_produce_correct_value(T expectedValue, byte[] inputBytes)
 	{
-		Span<byte> nodeBytes = new byte[inputBytes.Length];
+		// Over-allocate read buffer to ensure that the serializer doesn't get greedy with reading from the read buffer
+		// If the serializer reads into the extra buffer space, presumably it will not produce the correct result.
+		Span<byte> nodeBytes = new byte[inputBytes.Length + EXTRA_BUFFER_SPACE];
 		inputBytes.CopyTo(nodeBytes);
 		ReadOnlySpan<byte> readBuffer = nodeBytes;
 


### PR DESCRIPTION
- Instead of submitting the serialized bytes to the data source itself, the serializer now just modifies a given write buffer with its binary representation. It is then the responsibility of the caller to submit this representation to the data source.
- Also adds a `NodeSizeForObject` method, which gives the caller a way to know how many bytes should be allocated for the write buffer before serializing.

PANDO-56, PANDO-59